### PR TITLE
[#68] 360Giving naming fix in the package schema

### DIFF
--- a/schema/360-giving-package-schema.json
+++ b/schema/360-giving-package-schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Schema for a Three Sixty Giving Data Grant Package",
+    "title": "Schema for a 360Giving Data Grant Package",
     "type": "object",
     "required": ["grants"],
     "properties": {


### PR DESCRIPTION
360Giving is always 360Giving

Again, just stacking this up.