### PR TITLE
[#123] Remove titles for transactions

### DIFF
--- a/schema/360-giving-schema.json
+++ b/schema/360-giving-schema.json
@@ -583,8 +583,7 @@
       },
       "type": "array",
       "description": "-",
-      "weight": 5.02,
-      "title": "Amount applied for"
+      "weight": 5.02
     },
     "commitmentTransaction": {
       "items": {
@@ -592,8 +591,7 @@
       },
       "type": "array",
       "description": "-",
-      "weight": 5.02,
-      "title": "Amount awarded"
+      "weight": 5.02
     },
     "disbursementTransaction": {
          "items": {
@@ -601,8 +599,7 @@
          },
          "type": "array",
          "description": "-",
-         "weight": 5,
-         "title": "Amount paid out"
+         "weight": 5
        },
     "relatedActivity": {
       "type": "array",


### PR DESCRIPTION
As suggested in https://github.com/ThreeSixtyGiving/standard/issues/123#issuecomment-190253245

I've run the `sync-schema.sh`, and as suspected this doesn't seem to change anything in the docs.

I'm suggesting removing these completely for now, as this means they won't crop up anywhere in flatten-tool's titles support, which possibly puts us in a better position to change how transactions work.