### PR TITLE
Addresses 174 by allowing elements of scheme to be embedded into docs

### DIFF
--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -115,6 +115,8 @@ If you have additional data to report that does not fit any of the columns provi
 
 #### Actual Dates
 
+When did this grant activity actually take place. Dates should be in YYYY-MM-DD format. A date range can include a start date and duration in months, or a start and end date.
+
 |Title|Description|Type|Required|
 |----|----|----|----|
 |Actual Dates:Title|-|string|False|
@@ -127,6 +129,8 @@ If you have additional data to report that does not fit any of the columns provi
 
 #### Planned Dates
 
+When the applicant / implementing organisation originally intend this activity to take place. 
+
 |Title|Description|Type|Required|
 |----|----|----|----|
 |Planned Dates:Title|-|string|False|
@@ -138,6 +142,8 @@ If you have additional data to report that does not fit any of the columns provi
 
 
 #### Funding Org
+
+Details of the funder
 
 |Title|Description|Type|Required|
 |----|----|----|----|
@@ -163,6 +169,8 @@ If you have additional data to report that does not fit any of the columns provi
 
 #### Recipient Org
 
+Details of the recipient of this grant.
+
 |Title|Description|Type|Required|
 |----|----|----|----|
 |Recipient Org:Identifier|A globally unique identifier for this organisation. This is important to enable data on funders and recipients to be linked up across different grant-makers. The [Organisation Identifier Standard](http://www.threesixtygiving.org/standard/identifiers/#toc-organisation-identifier) guidance explains how to create this ID, based either on the known company or charity number, or upon identifiers held in the grant-maker's internal systems.|string|True|
@@ -187,6 +195,8 @@ If you have additional data to report that does not fit any of the columns provi
 
 #### Beneficiary Location
 
+Information about the location of beneficiaries. Further information about beneficiaries can be provided through classifications.
+
 |Title|Description|Type|Required|
 |----|----|----|----|
 |Beneficiary Location:Identifier|Location identifier|string|False|
@@ -201,6 +211,8 @@ If you have additional data to report that does not fit any of the columns provi
 
 
 #### Funding Org:Location
+
+-
 
 |Title|Description|Type|Required|
 |----|----|----|----|
@@ -217,6 +229,8 @@ If you have additional data to report that does not fit any of the columns provi
 
 #### Recipient Org:Location
 
+-
+
 |Title|Description|Type|Required|
 |----|----|----|----|
 |Recipient Org:Location:Identifier|Location identifier|string|False|
@@ -232,6 +246,8 @@ If you have additional data to report that does not fit any of the columns provi
 
 #### Related Document
 
+-
+
 |Title|Description|Type|Required|
 |----|----|----|----|
 |Related Document:Identifier|An identifier for this document.|string|False|
@@ -243,6 +259,8 @@ If you have additional data to report that does not fit any of the columns provi
 
 
 #### Classifications
+
+-
 
 |Title|Description|Type|Required|
 |----|----|----|----|
@@ -256,6 +274,8 @@ If you have additional data to report that does not fit any of the columns provi
 
 #### Funding Type
 
+-
+
 |Title|Description|Type|Required|
 |----|----|----|----|
 |Funding Type:Vocabulary|A vocabulary used for this classification.|string|False|
@@ -267,6 +287,8 @@ If you have additional data to report that does not fit any of the columns provi
 
 
 #### Grant Programme
+
+-
 
 |Title|Description|Type|Required|
 |----|----|----|----|

--- a/documentation/src/reference.md
+++ b/documentation/src/reference.md
@@ -74,45 +74,67 @@ If you have additional data to report that does not fit any of the columns provi
 
 #### Actual Dates
 
+{{properties.actualDates.description}}
+
 {{actualDates.csv|Title,Description,Type,Required}}
 
 #### Planned Dates
+
+{{properties.plannedDates.description}}
 
 {{plannedDates.csv|Title,Description,Type,Required}}
 
 #### Funding Org
 
+{{properties.fundingOrganization.description}}
+
 {{fundingOrganization.csv|Title,Description,Type,Required}}
 
 #### Recipient Org
+
+{{properties.recipientOrganization.description}}
 
 {{recipientOrganization.csv|Title,Description,Type,Required}}
 
 #### Beneficiary Location
 
+{{properties.beneficiaryLocation.description}}
+
 {{beneficiaryLocation.csv|Title,Description,Type,Required}}
 
 #### Funding Org:Location
+
+{{definitions.Organization.properties.location.description}}
 
 {{fun_location.csv|Title,Description,Type,Required}}
 
 #### Recipient Org:Location
 
+{{definitions.Organization.properties.location.description}}
+
 {{rec_location.csv|Title,Description,Type,Required}}
 
 #### Related Document
+
+{{properties.relatedDocument.description}}
 
 {{relatedDocument.csv|Title,Description,Type,Required}}
 
 #### Classifications
 
+{{properties.classifications.description}}
+
 {{classifications.csv|Title,Description,Type,Required}}
 
 #### Funding Type
 
+{{properties.fundingType.description}}
+
 {{fundingType.csv|Title,Description,Type,Required}}
 
 #### Grant Programme
+
+{{properties.grantProgramme.description}}
 
 {{grantProgramme.csv|Title,Description,Type,Required}}
 

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -1,6 +1,13 @@
 import re
 import os
 import csv
+import json
+
+def deep_access(x,keylist):
+     val = x
+     for key in keylist:
+         val = val[key]
+     return val
 
 def cleans(string):
     return string.replace("\n"," ")
@@ -10,23 +17,36 @@ for file in os.listdir("../documentation/src/"):
         with open("../documentation/src/" + file, 'r',encoding='utf-8') as f:
             string = str(f.read())
             for match in re.finditer("{{([a-zA-z\.]+)([|]*)([a-zA-z,]*)}}", string, flags=0):
-                table = ""
-                if(match.group(3)):
-                    cols = match.group(3).split(",")
+                # If we are dealing with a CSV file, embed the table
+                if ".csv" in match.group(1):
+                    table = ""
+                    if(match.group(3)):
+                        cols = match.group(3).split(",")
+                    else:
+                        cols = ['Title','Name','Description','Type','Format','Required']
+                    try:
+                        with open("../documentation/src/tabledefs/"+match.group(1),"r",encoding='utf-8') as csvfile:
+                            reader = csv.DictReader(csvfile)
+                            table += "|" + "|".join(cols) + "|\n"
+                            table += "|" + ("----|" * len(cols)) + "\n"
+                            for row in reader:
+                                for col in cols:
+                                    table += "|" + cleans(row[col.lower()])
+                                table += "|\n"
+                    except:
+                        pass
+                    string = string.replace(match.group(0),table)
+                # If it's not a CSV file, let's assume it is a json path in 36-giving-schema.json
                 else:
-                    cols = ['Title','Name','Description','Type','Format','Required']
-                try:
-                    with open("../documentation/src/tabledefs/"+match.group(1),"r",encoding='utf-8') as csvfile:
-                        reader = csv.DictReader(csvfile)
-                        table += "|" + "|".join(cols) + "|\n"
-                        table += "|" + ("----|" * len(cols)) + "\n"
-                        for row in reader:
-                            for col in cols:
-                                table += "|" + cleans(row[col.lower()])
-                            table += "|\n"
+                    with open("../schema/360-giving-schema.json",'r') as s:
+                        schema = json.loads(s.read())
+                        try:
+                            schema_text = deep_access(schema,match.group(1).split('.'))
+                        except:
+                            schema_text = "- Documentation Error: Schema path not found -"
 
-                except:
-                    pass
-                string = string.replace(match.group(0),table)
+                    string = string.replace(match.group(0),schema_text)
+
+
             with open("../documentation/"+ file,"w",encoding='utf-8') as write:
                 write.write(string)


### PR DESCRIPTION
This aims to address Edafe's issue in #174 by introducing a step to the build_docs.py script allowing embedding of arbitrary elements of the JSON schema into the reference docs. 

I've updated src/reference.md with the appropriate markup to pull in descriptions for each sub-table. 