### PR TITLE
Add text to index page

### DIFF
--- a/documentation/_static/basic.css
+++ b/documentation/_static/basic.css
@@ -16,4 +16,5 @@
 }
 .one_half p {
     margin: 1.6em 0;
+    text-align: center;
 }

--- a/documentation/_static/basic.css
+++ b/documentation/_static/basic.css
@@ -8,3 +8,12 @@
     border-color: #ff9222;
 }
 
+.one_half {
+    width: 45%;
+    padding-right: 2%;
+    padding-left: 2%;
+    float: left;
+}
+.one_half p {
+    margin: 1.6em 0;
+}

--- a/documentation/_templates/footer.html
+++ b/documentation/_templates/footer.html
@@ -1,0 +1,50 @@
+<footer>
+  {% if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
+    <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
+      {% if next %}
+        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
+      {% endif %}
+      {% if prev %}
+        <a href="{{ prev.link|e }}" class="btn btn-neutral" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  <hr/>
+
+  <div role="contentinfo">
+    <p>
+
+    © Copyright 2016-2017, 360Giving, licensed under a a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+
+    {% if pagename == 'index' %}
+    Icons from the Noun Project: Document by Jamison Wieser and JSON File by useiconic.com.
+    {% endif %}
+
+    {%- if build_id and build_url %}
+      {% trans build_url=build_url, build_id=build_id %}
+        <span class="build">
+          Build
+          <a href="{{ build_url }}">{{ build_id }}</a>.
+        </span>
+      {% endtrans %}
+    {%- elif commit %}
+      {% trans commit=commit %}
+        <span class="commit">
+          Revision <code>{{ commit }}</code>.
+        </span>
+      {% endtrans %}
+    {%- elif last_updated %}
+      {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
+    {%- endif %}
+
+    </p>
+  </div>
+
+  {%- if show_sphinx %}
+  {% trans %}Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/snide/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>{% endtrans %}.
+  {%- endif %}
+
+  {%- block extrafooter %} {% endblock %}
+
+</footer>

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -1,8 +1,41 @@
-360Giving Data Standard
-=======================
+The 360Giving open data Standard
+================================
 
+**For open data to be really useful it has to follow an agreed format – *a standard* – so it can be easily compared with data from other organisations.**
 
-Contents:
+For UK grantmakers, we have developed the 360Giving Standard for this purpose. We use this Standard to make sure that when all your data is linked to the 360Giving Registry, it can be easily “read” by different applications. This is how we make sure that when you use the data, the results that come up can be compared.
+
+The 360Giving data standard is:
+* **Open data driven:** providing a common way to share transparent and interoperable information on grant-making.
+* **Easy to use:** offering a simple spreadsheet format for publishing and consuming data, backed up by a structured data model, developer-friendly JSON serialisation, and conversion tools.
+* **Comprehensive:** providing a 360 degree view of grantmaking. Describing the whole grantmaking process and supporting in-depth analysis of grants, grantees and beneficiaries.
+ 
+
+## Templates
+
+Two standard templates are available.
+
+<div class='content-column one_half'><p style="text-align: center;"><a href="https://github.com/ThreeSixtyGiving/standard/raw/legacy/schema/summary-table/360-giving-schema-titles.xlsx"><img class="alignnone wp-image-369 size-full" src="https://www.threesixtygiving.org/wp-content/uploads/noun_5872_cc.png" alt="Spreadsheet Icon" width="150" height="150" srcset="https://www.threesixtygiving.org/wp-content/uploads/noun_5872_cc.png 150w, https://www.threesixtygiving.org/wp-content/uploads/noun_5872_cc-100x100.png 100w" sizes="(max-width: 150px) 100vw, 150px" /></a></p>
+<div style="font-size: 0.7em; text-align: center;margin:-25px 0;">(Document by Jamison Wieser from the Noun Project)</div>
+<p style="text-align: center;"><strong><a href="https://github.com/ThreeSixtyGiving/standard/raw/legacy/schema/summary-table/360-giving-schema-titles.xlsx">Spreadsheet Template (Excel)</a></strong>, with user-friendly column headings, summary sheet and tabs for additional information.<br />
+(<a href="https://github.com/ThreeSixtyGiving/standard/tree/legacy/schema/summary-table/360-giving-schema-titles.csv">CSV versions also available</a>.)</p></div>
+<div class='content-column one_half'><p style="text-align: center;"><a href="http://www.threesixtygiving.org/standard/reference/#toc-360giving-json-schemas"><img class="alignnone size-thumbnail wp-image-101" src="https://www.threesixtygiving.org/wp-content/uploads/2015/07/json-150x150.png" alt="json" width="150" height="150" /></a></p>
+<div style="font-size: 0.7em; text-align: center;margin:-25px 0;">(JSON File by useiconic.com from the Noun Project)</div>
+<p style="text-align: center;">Our <a href="http://www.threesixtygiving.org/standard/reference/#toc-360giving-json-schemas">JSON Schema</a> provides the canonical definition of fields, as well as developer-friendly structure for working with 360Giving data.</p></div>
+<br clear="all" />
+
+Free support, helping you to publish and use 360Giving data is [available from our data support team](http://www.threesixtygiving.org/contact/).
+
+Full schema documentation is [available on the reference page](reference).
+
+## An open standard
+
+The 360Giving data standard is an open standard. You can get involved in shaping the development of the standard through:
+* [The 360 Discuss google group](https://groups.google.com/forum/#!forum/360-discuss): open for general discussions of the standard.
+* [The issue tracker for the standard](https://github.com/ThreeSixtyGiving/standard/issues): for bug reports and proposed updates to the standard.
+You can also contact the 360Giving data support team with your questions and suggestions.
+
+## Contents
 
 ```eval_rst
 .. toctree::
@@ -13,14 +46,4 @@ Contents:
    data-protection
    licensing
 ```
-
-
-
-Indices and tables
-==================
-
-```eval_rst
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-```
+ 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -15,13 +15,17 @@ The 360Giving data standard is:
 
 Two standard templates are available.
 
-<div class='content-column one_half'><p style="text-align: center;"><a href="https://github.com/ThreeSixtyGiving/standard/raw/legacy/schema/summary-table/360-giving-schema-titles.xlsx"><img class="alignnone wp-image-369 size-full" src="https://www.threesixtygiving.org/wp-content/uploads/noun_5872_cc.png" alt="Spreadsheet Icon" width="150" height="150" srcset="https://www.threesixtygiving.org/wp-content/uploads/noun_5872_cc.png 150w, https://www.threesixtygiving.org/wp-content/uploads/noun_5872_cc-100x100.png 100w" sizes="(max-width: 150px) 100vw, 150px" /></a></p>
+<div class='content-column one_half'><p><a href="https://github.com/ThreeSixtyGiving/standard/raw/legacy/schema/summary-table/360-giving-schema-titles.xlsx"><img class="alignnone wp-image-369 size-full" src="https://www.threesixtygiving.org/wp-content/uploads/noun_5872_cc.png" alt="Spreadsheet Icon" width="150" height="150" srcset="https://www.threesixtygiving.org/wp-content/uploads/noun_5872_cc.png 150w, https://www.threesixtygiving.org/wp-content/uploads/noun_5872_cc-100x100.png 100w" sizes="(max-width: 150px) 100vw, 150px" /></a></p>
 <div style="font-size: 0.7em; text-align: center;margin:-25px 0;">(Document by Jamison Wieser from the Noun Project)</div>
-<p style="text-align: center;"><strong><a href="https://github.com/ThreeSixtyGiving/standard/raw/legacy/schema/summary-table/360-giving-schema-titles.xlsx">Spreadsheet Template (Excel)</a></strong>, with user-friendly column headings, summary sheet and tabs for additional information.<br />
-(<a href="https://github.com/ThreeSixtyGiving/standard/tree/legacy/schema/summary-table/360-giving-schema-titles.csv">CSV versions also available</a>.)</p></div>
-<div class='content-column one_half'><p style="text-align: center;"><a href="http://www.threesixtygiving.org/standard/reference/#toc-360giving-json-schemas"><img class="alignnone size-thumbnail wp-image-101" src="https://www.threesixtygiving.org/wp-content/uploads/2015/07/json-150x150.png" alt="json" width="150" height="150" /></a></p>
+<p><strong><a href="_static/summary-table/360-giving-schema-titles.xlsx">Spreadsheet Template (Excel)</a></strong>, with user-friendly column headings, summary sheet and tabs for additional information.<br />
+(<a href="templates-csv">CSV versions also available</a>.)</p></div>
+<div class='content-column one_half'><p><a href="http://www.threesixtygiving.org/standard/reference/#toc-360giving-json-schemas"><img class="alignnone size-thumbnail wp-image-101" src="https://www.threesixtygiving.org/wp-content/uploads/2015/07/json-150x150.png" alt="json" width="150" height="150" /></a></p>
 <div style="font-size: 0.7em; text-align: center;margin:-25px 0;">(JSON File by useiconic.com from the Noun Project)</div>
-<p style="text-align: center;">Our <a href="http://www.threesixtygiving.org/standard/reference/#toc-360giving-json-schemas">JSON Schema</a> provides the canonical definition of fields, as well as developer-friendly structure for working with 360Giving data.</p></div>
+<p>
+
+Our [JSON Schema](360giving-json-schemas) provide the canonical definition of fields, as well as developer-friendly structure for working with 360Giving data.
+
+</p></div>
 <br clear="all" />
 
 Free support, helping you to publish and use 360Giving data is [available from our data support team](http://www.threesixtygiving.org/contact/).

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -16,11 +16,9 @@ The 360Giving data standard is:
 Two standard templates are available.
 
 <div class='content-column one_half'><p><a href="https://github.com/ThreeSixtyGiving/standard/raw/legacy/schema/summary-table/360-giving-schema-titles.xlsx"><img class="alignnone wp-image-369 size-full" src="https://www.threesixtygiving.org/wp-content/uploads/noun_5872_cc.png" alt="Spreadsheet Icon" width="150" height="150" srcset="https://www.threesixtygiving.org/wp-content/uploads/noun_5872_cc.png 150w, https://www.threesixtygiving.org/wp-content/uploads/noun_5872_cc-100x100.png 100w" sizes="(max-width: 150px) 100vw, 150px" /></a></p>
-<div style="font-size: 0.7em; text-align: center;margin:-25px 0;">(Document by Jamison Wieser from the Noun Project)</div>
 <p><strong><a href="_static/summary-table/360-giving-schema-titles.xlsx">Spreadsheet Template (Excel)</a></strong>, with user-friendly column headings, summary sheet and tabs for additional information.<br />
 (<a href="templates-csv">CSV versions also available</a>.)</p></div>
 <div class='content-column one_half'><p><a href="http://www.threesixtygiving.org/standard/reference/#toc-360giving-json-schemas"><img class="alignnone size-thumbnail wp-image-101" src="https://www.threesixtygiving.org/wp-content/uploads/2015/07/json-150x150.png" alt="json" width="150" height="150" /></a></p>
-<div style="font-size: 0.7em; text-align: center;margin:-25px 0;">(JSON File by useiconic.com from the Noun Project)</div>
 <p>
 
 Our [JSON Schema](360giving-json-schemas) provide the canonical definition of fields, as well as developer-friendly structure for working with 360Giving data.


### PR DESCRIPTION
Text moved from http://www.threesixtygiving.org/standard/.
This is a page introducing a standard, so I think it belongs in the standard docs, rather than the wordpress.
Moving this means that we can also blanket redirect http://www.threesixtygiving.org/standard/ to the new standard site.

Preview of what this looks like https://threesixtygiving-standard.readthedocs.io/en/index-page/