### PR TITLE
[#212] Rewrite old url hashes

### DIFF
--- a/documentation/_templates/layout.html
+++ b/documentation/_templates/layout.html
@@ -24,3 +24,9 @@ Data Standard
    <li class="toctree-l1"><a href="http://www.threesixtygiving.org/">360Giving main website</a></li>
 </ul>
 {% endblock %}
+
+{% block footer %}
+<script type="text/javascript">
+    window.location.hash = window.location.hash.replace('#toc-', '#') // look for old anchors starting #toc- and remove that bit
+</script>
+{% endblock %}


### PR DESCRIPTION
#212 

Examples:
http://standard.threesixtygiving.org/en/212-hash-redirect/reference/#toc-grants-sheet
http://standard.threesixtygiving.org/en/212-hash-redirect/licensing/#toc-is-there-an-example-of-a-license-statement-
http://standard.threesixtygiving.org/en/212-hash-redirect/identifiers/#toc-organisation-identifier
http://standard.threesixtygiving.org/en/212-hash-redirect/identifiers/#toc-grant-identifier
http://standard.threesixtygiving.org/en/212-hash-redirect/identifiers/#toc-why-identifiers-matter

These all look to work except for http://standard.threesixtygiving.org/en/212-hash-redirect/licensing/#toc-is-there-an-example-of-a-license-statement-