### PR TITLE
Additional (publisher own) field titles - character usage

### DIFF
--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -221,7 +221,7 @@ You can:
 * **Remove or hide non-required columns that you are not using** - although make sure you check any [hidden columns](#hidden-columns) before publishing your data, and always remove rather than hide sensitive information.
 * **Re-order the columns** so that information is arranged in the way you want
 * **Add extra columns** to include information you want to share, but that is not covered by the standard. (See [additional fields](additional-fields)).
-* Move columns in the <a href="../_static/summary-table/360-giving-schema-titles.xlsx">360Giving Spreadsheet Template</a> between sheets.
+* **Move columns** in the <a href="../_static/summary-table/360-giving-schema-titles.xlsx">360Giving Spreadsheet Template</a> between sheets.
 
 You must not:
 

--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -77,11 +77,12 @@ If, when creating your data, you only need a few additional fields from the addi
 
 If you have additional data to report that does not fit any of the columns provided in the spreadsheet, it is okay to create your own column titles in order to report it.
 
-.. hint:: Adding your own columns:
+```eval_rst
+.. hint:: **Naming your own columns.**
 
   If you are adding your own column titles it is best to use simple titles and to avoid special characters which could cause problems in data reuse.
 
-  Using only lowercase and uppercase alphabetical characters (``a-z`` and ``A-Z``), numerical digits (``0-9``) colons (``:``), parentheses (``(`` and ``)``) and single spaces will help to avoid problems. Other characters could be used, but haven't been fully tested in all possible situations.
+  Using only lowercase and uppercase alphabetical characters (``a-z`` and ``A-Z``), numerical digits (``0-9``), colons (``:``), parentheses (``(`` and ``)``) and single spaces will help to avoid problems. Full-stops (``.``) are known to cause issues and should be avoided. Other characters could be used, but haven't been fully tested in all possible situations.
 ```
 
 #### Actual Dates

--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -218,7 +218,7 @@ You must:
 
 You can:
 
-* **Remove or hide non-required columns that you are not using** - although make sure you check any [hidden columns](#hidden-columns) before publishing your data, and always remove rather than hide sensitive information.
+* **Remove or hide non-required columns that you are not using** - although make sure you check for any [hidden columns](#hidden-columns) before publishing your data, and always remove rather than hide sensitive information.
 * **Re-order the columns** so that information is arranged in the way you want
 * **Add extra columns** to include information you want to share, but that is not covered by the standard. (See [additional fields](additional-fields)).
 * **Move columns** in the <a href="../_static/summary-table/360-giving-schema-titles.xlsx">360Giving Spreadsheet Template</a> between sheets.

--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -220,7 +220,7 @@ You can:
 
 * **Remove or hide non-required columns that you are not using** - although make sure you check any [hidden columns](#hidden-columns) before publishing your data, and always remove rather than hide sensitive information.
 * **Re-order the columns** so that information is arranged in the way you want
-* **Add extra columns** to include information you want to share, but that is not covered by the standard. 
+* **Add extra columns** to include information you want to share, but that is not covered by the standard. (See [additional fields](additional-fields)).
 * Move columns in the <a href="../_static/summary-table/360-giving-schema-titles.xlsx">360Giving Spreadsheet Template</a> between sheets.
 
 You must not:

--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -77,6 +77,12 @@ If, when creating your data, you only need a few additional fields from the addi
 
 If you have additional data to report that does not fit any of the columns provided in the spreadsheet, it is okay to create your own column titles in order to report it.
 
+.. hint:: Adding your own columns:
+
+  If you are adding your own column titles it is best to use simple titles and to avoid special characters which could cause problems in data reuse.
+
+  Using only lowercase and uppercase alphabetical characters (``a-z`` and ``A-Z``), numerical digits (``0-9``) colons (``:``), parentheses (``(`` and ``)``) and single spaces will help to avoid problems. Other characters could be used, but haven't been fully tested in all possible situations.
+```
 
 #### Actual Dates
 


### PR DESCRIPTION
Re #223  'Dots in (publisher own) field titles can cause problems'.

On the 'reference' page, beneath where it says:
> If you have additional data to report that does not fit any of the columns provided in the spreadsheet, it is okay to create your own column titles in order to report it.

I've added a _hint box_ with:
> Adding your own columns:
> If you are adding your own column titles it is best to use simple titles and to avoid special characters which could cause problems in data reuse.
>  Using only lowercase and uppercase alphabetical characters (``a-z`` and ``A-Z``), numerical digits (``0-9``) colons (``:``), parentheses (``(`` and ``)``) and single spaces will help to avoid problems. Other characters could be used, but haven't been fully tested in all possible situations.

This might be a bit verbose, we could drop the last line? Also, it's the only hint box on that page, and so sticks out a bit.