### PR TITLE
Add script to update currency codes in the schema

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,6 @@ snowballstemmer==1.2.1
 urllib3==1.20
 jdcal==1.2
 jsonref==0.1
+lxml==4.1.1
 openpyxl==2.3.2
 schema==0.4.0

--- a/schema/360-giving-schema.json
+++ b/schema/360-giving-schema.json
@@ -1,23 +1,324 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "360Giving Data Standard Schema",
-  "type":"object",
+  "type": "object",
   "definitions": {
-      "currency": {
-        "type": "string",
-        "description": "The currency used in amounts. Use the three-letter currency code from [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) eg: Use GBP for Pounds Sterling.",
-        "weight": 5.02,
-        "enum": ["AED","AFN","ALL","AMD","ANG","AOA","ARS","AUD","AWG","AZN","BAM","BBD","BDT","BGN","BHD","BIF","BMD","BND","BOB","BRL","BSD","BTN","BWP","BYR","BZD","CAD","CDF","CHF","CLP","CNY","COP","CRC","CUC","CUP","CVE","CZK","DJF","DKK","DOP","DZD","EGP","ERN","ETB","EUR","FJD","FKP","GBP","GEL","GGP","GHS","GIP","GMD","GNF","GTQ","GYD","HKD","HNL","HRK","HTG","HUF","IDR","ILS","IMP","INR","IQD","IRR","ISK","JEP","JMD","JOD","JPY","KES","KGS","KHR","KMF","KPW","KRW","KWD","KYD","KZT","LAK","LBP","LKR","LRD","LSL","LTL","LVL","LYD","MAD","MDL","MGA","MKD","MMK","MNT","MOP","MRO","MUR","MVR","MWK","MXN","MYR","MZN","NAD","NGN","NIO","NOK","NPR","NZD","OMR","PAB","PEN","PGK","PHP","PKR","PLN","PYG","QAR","RON","RSD","RUB","RWF","SAR","SBD","SCR","SDG","SEK","SGD","SHP","SLL","SOS","SPL","SRD","STD","SVC","SYP","SZL","THB","TJS","TMT","TND","TOP","TRY","TTD","TVD","TWD","TZS","UAH","UGX","USD","UYU","UZS","VEF","VND","VUV","WST","XAF","XCD","XDR","XOF","XPF","YER","ZAR","ZMW","ZWD"],
-        "title": "Currency"
-      },
+    "currency": {
+      "type": "string",
+      "description": "The currency used in amounts. Use the three-letter currency code from [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) eg: Use GBP for Pounds Sterling.",
+      "weight": 5.02,
+      "enum": [
+        "ADP",
+        "AED",
+        "AFA",
+        "AFN",
+        "ALK",
+        "ALL",
+        "AMD",
+        "ANG",
+        "AOA",
+        "AOK",
+        "AON",
+        "AOR",
+        "ARA",
+        "ARP",
+        "ARS",
+        "ARY",
+        "ATS",
+        "AUD",
+        "AWG",
+        "AYM",
+        "AZM",
+        "AZN",
+        "BAD",
+        "BAM",
+        "BBD",
+        "BDT",
+        "BEC",
+        "BEF",
+        "BEL",
+        "BGJ",
+        "BGK",
+        "BGL",
+        "BGN",
+        "BHD",
+        "BIF",
+        "BMD",
+        "BND",
+        "BOB",
+        "BOP",
+        "BOV",
+        "BRB",
+        "BRC",
+        "BRE",
+        "BRL",
+        "BRN",
+        "BRR",
+        "BSD",
+        "BTN",
+        "BUK",
+        "BWP",
+        "BYB",
+        "BYN",
+        "BYR",
+        "BZD",
+        "CAD",
+        "CDF",
+        "CHC",
+        "CHE",
+        "CHF",
+        "CHW",
+        "CLF",
+        "CLP",
+        "CNY",
+        "COP",
+        "COU",
+        "CRC",
+        "CSD",
+        "CSJ",
+        "CSK",
+        "CUC",
+        "CUP",
+        "CVE",
+        "CYP",
+        "CZK",
+        "DDM",
+        "DEM",
+        "DJF",
+        "DKK",
+        "DOP",
+        "DZD",
+        "ECS",
+        "ECV",
+        "EEK",
+        "EGP",
+        "ERN",
+        "ESA",
+        "ESB",
+        "ESP",
+        "ETB",
+        "EUR",
+        "FIM",
+        "FJD",
+        "FKP",
+        "FRF",
+        "GBP",
+        "GEK",
+        "GEL",
+        "GHC",
+        "GHP",
+        "GHS",
+        "GIP",
+        "GMD",
+        "GNE",
+        "GNF",
+        "GNS",
+        "GQE",
+        "GRD",
+        "GTQ",
+        "GWE",
+        "GWP",
+        "GYD",
+        "HKD",
+        "HNL",
+        "HRD",
+        "HRK",
+        "HTG",
+        "HUF",
+        "IDR",
+        "IEP",
+        "ILP",
+        "ILR",
+        "ILS",
+        "INR",
+        "IQD",
+        "IRR",
+        "ISJ",
+        "ISK",
+        "ITL",
+        "JMD",
+        "JOD",
+        "JPY",
+        "KES",
+        "KGS",
+        "KHR",
+        "KMF",
+        "KPW",
+        "KRW",
+        "KWD",
+        "KYD",
+        "KZT",
+        "LAJ",
+        "LAK",
+        "LBP",
+        "LKR",
+        "LRD",
+        "LSL",
+        "LSM",
+        "LTL",
+        "LTT",
+        "LUC",
+        "LUF",
+        "LUL",
+        "LVL",
+        "LVR",
+        "LYD",
+        "MAD",
+        "MDL",
+        "MGA",
+        "MGF",
+        "MKD",
+        "MLF",
+        "MMK",
+        "MNT",
+        "MOP",
+        "MRO",
+        "MRU",
+        "MTL",
+        "MTP",
+        "MUR",
+        "MVQ",
+        "MVR",
+        "MWK",
+        "MXN",
+        "MXP",
+        "MXV",
+        "MYR",
+        "MZE",
+        "MZM",
+        "MZN",
+        "NAD",
+        "NGN",
+        "NIC",
+        "NIO",
+        "NLG",
+        "NOK",
+        "NPR",
+        "NZD",
+        "OMR",
+        "PAB",
+        "PEH",
+        "PEI",
+        "PEN",
+        "PES",
+        "PGK",
+        "PHP",
+        "PKR",
+        "PLN",
+        "PLZ",
+        "PTE",
+        "PYG",
+        "QAR",
+        "RHD",
+        "ROK",
+        "ROL",
+        "RON",
+        "RSD",
+        "RUB",
+        "RUR",
+        "RWF",
+        "SAR",
+        "SBD",
+        "SCR",
+        "SDD",
+        "SDG",
+        "SDP",
+        "SEK",
+        "SGD",
+        "SHP",
+        "SIT",
+        "SKK",
+        "SLL",
+        "SOS",
+        "SRD",
+        "SRG",
+        "SSP",
+        "STD",
+        "STN",
+        "SUR",
+        "SVC",
+        "SYP",
+        "SZL",
+        "THB",
+        "TJR",
+        "TJS",
+        "TMM",
+        "TMT",
+        "TND",
+        "TOP",
+        "TPE",
+        "TRL",
+        "TRY",
+        "TTD",
+        "TWD",
+        "TZS",
+        "UAH",
+        "UAK",
+        "UGS",
+        "UGW",
+        "UGX",
+        "USD",
+        "USN",
+        "USS",
+        "UYI",
+        "UYN",
+        "UYP",
+        "UYU",
+        "UZS",
+        "VEB",
+        "VEF",
+        "VNC",
+        "VND",
+        "VUV",
+        "WST",
+        "XAF",
+        "XAG",
+        "XAU",
+        "XBA",
+        "XBB",
+        "XBC",
+        "XBD",
+        "XCD",
+        "XDR",
+        "XEU",
+        "XFO",
+        "XFU",
+        "XOF",
+        "XPD",
+        "XPF",
+        "XPT",
+        "XRE",
+        "XSU",
+        "XTS",
+        "XUA",
+        "XXX",
+        "YDD",
+        "YER",
+        "YUD",
+        "YUM",
+        "YUN",
+        "ZAL",
+        "ZAR",
+        "ZMK",
+        "ZMW",
+        "ZRN",
+        "ZRZ",
+        "ZWC",
+        "ZWD",
+        "ZWL",
+        "ZWN",
+        "ZWR"
+      ],
+      "title": "Currency"
+    },
     "Transaction": {
       "type": "object",
       "properties": {
         "id": {
-            "type": "string",
-            "description": "Identifier",
-            "weight": 0.001,
-            "title": "Identifier"
+          "type": "string",
+          "description": "Identifier",
+          "weight": 0.001,
+          "title": "Identifier"
         },
         "transactionDate": {
           "format": "date-time",
@@ -37,25 +338,37 @@
         },
         "valueDate": {
           "format": "date-time",
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "The date that this value was set (to allow historical currency conversion). The date must be in ISO 8601 format (YYYY-MM-DD).",
           "weight": 6.1,
           "title": "Value date"
         },
         "description": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "A description of this transaction.",
           "weight": 9,
           "title": "Description"
         },
         "provider": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "The organisation identifier of the provider of transaction funds.",
           "weight": 0.6,
           "title": "Provider"
         },
         "recipient": {
-         "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "The organisation identifier of the recipient of transaction funds.",
           "weight": 0.7,
           "title": "Recipient"
@@ -73,32 +386,44 @@
       "type": "object",
       "properties": {
         "id": {
-            "type": "string",
-            "description": "An identifier for this document.",
-            "weight": 0.001,
-            "title": "Identifier"
+          "type": "string",
+          "description": "An identifier for this document.",
+          "weight": 0.001,
+          "title": "Identifier"
         },
         "title": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "The document title",
           "weight": 1.05,
           "title": "Title"
         },
         "url": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "uri",
           "description": "The URL of the document.",
           "weight": 11.01,
           "title": "Web Address"
         },
         "description": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "A description of the document",
           "weight": 9,
           "title": "Description"
         },
         "documentType": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "A document category. For example, 'Application Form', 'Photo' or 'Project Report'. In future, 360Giving will provide a codelist of document types.",
           "weight": 0.8,
           "title": "Document Type"
@@ -115,54 +440,325 @@
     "Location": {
       "type": "object",
       "properties": {
-       "id": {
-         "type": "string",
-         "description": "Location identifier",
-         "weight": 0.001,
-         "title": "Identifier"
+        "id": {
+          "type": "string",
+          "description": "Location identifier",
+          "weight": 0.001,
+          "title": "Identifier"
         },
         "name": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "A name for this location.",
           "weight": 1.1,
           "title": "Name"
         },
         "countryCode": {
-          "type": ["string","null"],
-          "enum": ["AF","AX","AL","DZ","AS","AD","AO","AI","AQ","AG","AR","AM","AW","AU","AT","AZ","BS","BH","BD","BB","BY","BE","BZ","BJ","BM","BT","BO","BQ","BA","BW","BV","BR","IO","BN","BG","BF","BI","KH","CM","CA","CV","KY","CF","TD","CL","CN","CX","CC","CO","KM","CG","CD","CK","CR","CI","HR","CU","CW","CY","CZ","DK","DJ","DM","DO","EC","EG","SV","GQ","ER","EE","ET","FK","FO","FJ","FI","FR","GF","PF","TF","GA","GM","GE","DE","GH","GI","GR","GL","GD","GP","GU","GT","GG","GN","GW","GY","HT","HM","VA","HN","HK","HU","IS","IN","ID","IR","IQ","IE","IM","IL","IT","JM","JP","JE","JO","KZ","KE","KI","KP","KR","KW","KG","LA","LV","LB","LS","LR","LY","LI","LT","LU","MO","MK","MG","MW","MY","MV","ML","MT","MH","MQ","MR","MU","YT","MX","FM","MD","MC","MN","ME","MS","MA","MZ","MM","NA","NR","NP","NL","NC","NZ","NI","NE","NG","NU","NF","MP","NO","OM","PK","PW","PS","PA","PG","PY","PE","PH","PN","PL","PT","PR","QA","RE","RO","RU","RW","BL","SH","KN","LC","MF","PM","VC","WS","SM","ST","SA","SN","RS","SC","SL","SG","SX","SK","SI","SB","SO","ZA","GS","SS","ES","LK","SD","SR","SJ","SZ","SE","CH","SY","TW","TJ","TZ","TH","TL","TG","TK","TO","TT","TN","TR","TM","TC","TV","UG","UA","AE","GB","US","UM","UY","UZ","VU","VE","VN","VG","VI","WF","EH","YE","ZM","ZW"],
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "AF",
+            "AX",
+            "AL",
+            "DZ",
+            "AS",
+            "AD",
+            "AO",
+            "AI",
+            "AQ",
+            "AG",
+            "AR",
+            "AM",
+            "AW",
+            "AU",
+            "AT",
+            "AZ",
+            "BS",
+            "BH",
+            "BD",
+            "BB",
+            "BY",
+            "BE",
+            "BZ",
+            "BJ",
+            "BM",
+            "BT",
+            "BO",
+            "BQ",
+            "BA",
+            "BW",
+            "BV",
+            "BR",
+            "IO",
+            "BN",
+            "BG",
+            "BF",
+            "BI",
+            "KH",
+            "CM",
+            "CA",
+            "CV",
+            "KY",
+            "CF",
+            "TD",
+            "CL",
+            "CN",
+            "CX",
+            "CC",
+            "CO",
+            "KM",
+            "CG",
+            "CD",
+            "CK",
+            "CR",
+            "CI",
+            "HR",
+            "CU",
+            "CW",
+            "CY",
+            "CZ",
+            "DK",
+            "DJ",
+            "DM",
+            "DO",
+            "EC",
+            "EG",
+            "SV",
+            "GQ",
+            "ER",
+            "EE",
+            "ET",
+            "FK",
+            "FO",
+            "FJ",
+            "FI",
+            "FR",
+            "GF",
+            "PF",
+            "TF",
+            "GA",
+            "GM",
+            "GE",
+            "DE",
+            "GH",
+            "GI",
+            "GR",
+            "GL",
+            "GD",
+            "GP",
+            "GU",
+            "GT",
+            "GG",
+            "GN",
+            "GW",
+            "GY",
+            "HT",
+            "HM",
+            "VA",
+            "HN",
+            "HK",
+            "HU",
+            "IS",
+            "IN",
+            "ID",
+            "IR",
+            "IQ",
+            "IE",
+            "IM",
+            "IL",
+            "IT",
+            "JM",
+            "JP",
+            "JE",
+            "JO",
+            "KZ",
+            "KE",
+            "KI",
+            "KP",
+            "KR",
+            "KW",
+            "KG",
+            "LA",
+            "LV",
+            "LB",
+            "LS",
+            "LR",
+            "LY",
+            "LI",
+            "LT",
+            "LU",
+            "MO",
+            "MK",
+            "MG",
+            "MW",
+            "MY",
+            "MV",
+            "ML",
+            "MT",
+            "MH",
+            "MQ",
+            "MR",
+            "MU",
+            "YT",
+            "MX",
+            "FM",
+            "MD",
+            "MC",
+            "MN",
+            "ME",
+            "MS",
+            "MA",
+            "MZ",
+            "MM",
+            "NA",
+            "NR",
+            "NP",
+            "NL",
+            "NC",
+            "NZ",
+            "NI",
+            "NE",
+            "NG",
+            "NU",
+            "NF",
+            "MP",
+            "NO",
+            "OM",
+            "PK",
+            "PW",
+            "PS",
+            "PA",
+            "PG",
+            "PY",
+            "PE",
+            "PH",
+            "PN",
+            "PL",
+            "PT",
+            "PR",
+            "QA",
+            "RE",
+            "RO",
+            "RU",
+            "RW",
+            "BL",
+            "SH",
+            "KN",
+            "LC",
+            "MF",
+            "PM",
+            "VC",
+            "WS",
+            "SM",
+            "ST",
+            "SA",
+            "SN",
+            "RS",
+            "SC",
+            "SL",
+            "SG",
+            "SX",
+            "SK",
+            "SI",
+            "SB",
+            "SO",
+            "ZA",
+            "GS",
+            "SS",
+            "ES",
+            "LK",
+            "SD",
+            "SR",
+            "SJ",
+            "SZ",
+            "SE",
+            "CH",
+            "SY",
+            "TW",
+            "TJ",
+            "TZ",
+            "TH",
+            "TL",
+            "TG",
+            "TK",
+            "TO",
+            "TT",
+            "TN",
+            "TR",
+            "TM",
+            "TC",
+            "TV",
+            "UG",
+            "UA",
+            "AE",
+            "GB",
+            "US",
+            "UM",
+            "UY",
+            "UZ",
+            "VU",
+            "VE",
+            "VN",
+            "VG",
+            "VI",
+            "WF",
+            "EH",
+            "YE",
+            "ZM",
+            "ZW"
+          ],
           "description": "The ISO Country Code of the location of this activity.",
           "weight": 2,
           "title": "Country Code"
         },
         "latitude": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "The latitude of a point location",
           "weight": 4.001,
           "title": "Latitude"
         },
         "longitude": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "The longitude of a point location",
           "weight": 4.002,
           "title": "Longitude"
         },
         "description": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "A description of this location. This could include details of the element of the activity that takes place here.",
           "weight": 9,
           "title": "Description"
         },
         "geoCode": {
-          "type": ["string","null"],
-          "description":"A code referring to a geographical area, drawn from an established gazetteer. For example, the code for a local authority ward, or parliamentary constituency.",
-          "weight":5,
-          "title":"Geographic Code"
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "A code referring to a geographical area, drawn from an established gazetteer. For example, the code for a local authority ward, or parliamentary constituency.",
+          "weight": 5,
+          "title": "Geographic Code"
         },
         "geoCodeType": {
-          "type": ["string","null"],
-          "description":"The type of Geographic Code (geoCode) used (e.g. Ward, Parliamentary Constituency etc.). This value for this field should be drawn from the [codelist of geographic code types](https://github.com/ThreeSixtyGiving/standard/tree/master/codelists/geoCodeType.csv).",
-          "weight":5.01,
-          "title":"Geographic Code Type"
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The type of Geographic Code (geoCode) used (e.g. Ward, Parliamentary Constituency etc.). This value for this field should be drawn from the [codelist of geographic code types](https://github.com/ThreeSixtyGiving/standard/tree/master/codelists/geoCodeType.csv).",
+          "weight": 5.01,
+          "title": "Geographic Code Type"
         },
         "dateModified": {
           "format": "date-time",
@@ -189,19 +785,28 @@
           "title": "Code"
         },
         "title": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "The title of this classification.",
           "weight": 1.05,
           "title": "Title"
         },
         "description": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "A description of this classification.",
           "weight": 9,
           "title": "Description"
-        },    
+        },
         "url": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "uri",
           "description": "A web link to more details of this classification.",
           "weight": 9,
@@ -217,46 +822,57 @@
       }
     },
     "GrantProgramme": {
-              "type": "object",
-              "properties": {
-               "code": {
-                 "type": "string",
-                 "description": "An identifier for this grant programme.",
-                 "weight": 9,
-                 "title": "Code"
-               },
-               "title": {
-                 "type": ["string","null"],
-                 "description": "The title of this grant programme.",
-                 "weight": 1.05,
-                 "title": "Title"
-               },
-               "description": {
-                 "type": ["string","null"],
-                 "description": "A description of this grant programme.",
-                 "weight": 9,
-                 "title": "Description"
-               },    
-               "url": {
-                 "type": ["string","null"],
-                 "format": "uri",
-                 "description": "A web link to more details of this grant programme.",
-                 "weight": 9,
-                 "title": "URL"
-               },
-               "dateModified": {
-                 "format": "date-time",
-                 "type": "string",
-                 "description": "The date and time when information about this grant programme was last updated.",
-                 "weight": 25,
-                 "title": "Last modified"
-               }
-              }
-            },
-    
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "An identifier for this grant programme.",
+          "weight": 9,
+          "title": "Code"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The title of this grant programme.",
+          "weight": 1.05,
+          "title": "Title"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "A description of this grant programme.",
+          "weight": 9,
+          "title": "Description"
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri",
+          "description": "A web link to more details of this grant programme.",
+          "weight": 9,
+          "title": "URL"
+        },
+        "dateModified": {
+          "format": "date-time",
+          "type": "string",
+          "description": "The date and time when information about this grant programme was last updated.",
+          "weight": 25,
+          "title": "Last modified"
+        }
+      }
+    },
     "Organization": {
       "type": "object",
-      "required":["id","name"],
+      "required": [
+        "id",
+        "name"
+      ],
       "properties": {
         "id": {
           "type": "string",
@@ -271,9 +887,9 @@
           "title": "Name"
         },
         "department": {
-            "type":"string",
-            "description":"The department or sub-unit of this organisation making or receiving the grant.",
-            "title":"Department"
+          "type": "string",
+          "description": "The department or sub-unit of this organisation making or receiving the grant.",
+          "title": "Department"
         },
         "contactName": {
           "type": "string",
@@ -282,10 +898,10 @@
           "title": "Contact Name"
         },
         "charityNumber": {
-              "type": "string",
-              "description": "Registered charity number, if applicable.",
-              "weight": 6.01,
-              "title": "Charity Number"
+          "type": "string",
+          "description": "Registered charity number, if applicable.",
+          "weight": 6.01,
+          "title": "Charity Number"
         },
         "companyNumber": {
           "type": "string",
@@ -298,7 +914,7 @@
           "description": "Building number and street name.",
           "weight": 3.1,
           "title": "Street Address"
-        }, 
+        },
         "addressLocality": {
           "type": "string",
           "description": "City or town.",
@@ -324,10 +940,10 @@
           "title": "Postal Code"
         },
         "telephone": {
-         "type":"string",
-         "description":"Contact phone number.",
-         "weight":3.5,
-         "title": "Phone Number"
+          "type": "string",
+          "description": "Contact phone number.",
+          "weight": 3.5,
+          "title": "Phone Number"
         },
         "alternateName": {
           "type": "string",
@@ -335,7 +951,7 @@
           "weight": 6,
           "title": "Alternate Name"
         },
-      "email": {
+        "email": {
           "type": "string",
           "description": "The email address for this organisation.",
           "weight": 5,
@@ -348,9 +964,17 @@
           "title": "Description"
         },
         "organisationType": {
-          "type": ["string","null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "A description of this organisation",
-          "enum":["Registered Charity","Registered Company","Community Group","List to be updated"],
+          "enum": [
+            "Registered Charity",
+            "Registered Company",
+            "Community Group",
+            "List to be updated"
+          ],
           "weight": 5,
           "title": "Organisation Type"
         },
@@ -382,14 +1006,14 @@
     "Event": {
       "definitions": {},
       "type": "object",
-      "title":"Event",
-      "description":"An event in the life of the grant activity",
+      "title": "Event",
+      "description": "An event in the life of the grant activity",
       "properties": {
         "title": {
-            "type": "string",
-            "description": "-",
-            "weight": 1.05,
-            "title": "Title"
+          "type": "string",
+          "description": "-",
+          "weight": 1.05,
+          "title": "Title"
         },
         "startDate": {
           "format": "date-time",
@@ -417,17 +1041,26 @@
           "weight": 9,
           "title": "Description"
         },
-         "dateModified": {
-              "format": "date-time",
-              "type": "string",
-              "description": "The date and time when information about this event was last updated.",
-              "weight": 25,
-              "title": "Last modified"
-            }
+        "dateModified": {
+          "format": "date-time",
+          "type": "string",
+          "description": "The date and time when information about this event was last updated.",
+          "weight": 25,
+          "title": "Last modified"
+        }
       }
     }
   },
-  "required":["id","title","description","currency","amountAwarded","awardDate", "recipientOrganization", "fundingOrganization"],
+  "required": [
+    "id",
+    "title",
+    "description",
+    "currency",
+    "amountAwarded",
+    "awardDate",
+    "recipientOrganization",
+    "fundingOrganization"
+  ],
   "properties": {
     "id": {
       "type": "string",
@@ -452,21 +1085,21 @@
     },
     "amountAppliedFor": {
       "type": "number",
-      "description": "Total amount applied for in numbers (do not include commas or currency symbols such as £). If you have provided detailed transaction information on a separate table, this should equal the sum of all the application transactions for this grant.",
+      "description": "Total amount applied for in numbers (do not include commas or currency symbols such as \u00a3). If you have provided detailed transaction information on a separate table, this should equal the sum of all the application transactions for this grant.",
       "weight": 5.03,
       "title": "Amount Applied For"
     },
     "amountAwarded": {
       "type": "number",
-      "description": "Total amount awarded in numbers (do not include commas or currency symbols such as £). If you have provided detailed transaction information on a separate table, this should equal the sum of all the award transactions for this grant.",
+      "description": "Total amount awarded in numbers (do not include commas or currency symbols such as \u00a3). If you have provided detailed transaction information on a separate table, this should equal the sum of all the award transactions for this grant.",
       "weight": 5.04,
       "title": "Amount Awarded"
     },
     "amountDisbursed": {
-         "type": "number",
-         "description": "Total amount disbursed (paid) to this grantee when this record was last updated (in numbers: do not include commas or currency symbols such as £)). If you have provided detailed transaction information on a separate table, this should equal the sum of all the disbursement transactions for this grant.",
-         "weight": 5.04,
-         "title": "Amount Disbursed"
+      "type": "number",
+      "description": "Total amount disbursed (paid) to this grantee when this record was last updated (in numbers: do not include commas or currency symbols such as \u00a3)). If you have provided detailed transaction information on a separate table, this should equal the sum of all the disbursement transactions for this grant.",
+      "weight": 5.04,
+      "title": "Amount Disbursed"
     },
     "awardDate": {
       "format": "date-time",
@@ -489,8 +1122,12 @@
       "type": "array",
       "weight": 5.041,
       "title": "Planned Dates",
-      "description":"When the applicant / implementing organisation originally intend this activity to take place. ",
-      "rollUp": ["startDate","endDate","duration"]      
+      "description": "When the applicant / implementing organisation originally intend this activity to take place. ",
+      "rollUp": [
+        "startDate",
+        "endDate",
+        "duration"
+      ]
     },
     "actualDates": {
       "items": {
@@ -509,8 +1146,20 @@
       "type": "array",
       "weight": 5,
       "title": "Recipient Org",
-      "description":"Details of the recipient of this grant.",
-      "rollUp": ["id","name","charityNumber","companyNumber","streetAddress","addressLocality","addressRegion","postalCode","addressCountry","description","url"]      
+      "description": "Details of the recipient of this grant.",
+      "rollUp": [
+        "id",
+        "name",
+        "charityNumber",
+        "companyNumber",
+        "streetAddress",
+        "addressLocality",
+        "addressRegion",
+        "postalCode",
+        "addressCountry",
+        "description",
+        "url"
+      ]
     },
     "beneficiaryLocation": {
       "items": {
@@ -519,8 +1168,15 @@
       "type": "array",
       "weight": 6.01,
       "title": "Beneficiary Location",
-      "description":"Information about the location of beneficiaries. Further information about beneficiaries can be provided through classifications.",
-      "rollUp": ["name","countryCode","latitude","longitude","geoCode","geoCodeType"]
+      "description": "Information about the location of beneficiaries. Further information about beneficiaries can be provided through classifications.",
+      "rollUp": [
+        "name",
+        "countryCode",
+        "latitude",
+        "longitude",
+        "geoCode",
+        "geoCodeType"
+      ]
     },
     "fundingOrganization": {
       "items": {
@@ -531,7 +1187,11 @@
       "description": "Details of the funder",
       "weight": 4,
       "title": "Funding Org",
-      "rollUp": ["id","name","department"]
+      "rollUp": [
+        "id",
+        "name",
+        "department"
+      ]
     },
     "grantProgramme": {
       "items": {
@@ -541,11 +1201,18 @@
       "description": "-",
       "weight": 5,
       "title": "Grant Programme",
-      "rollUp": ["code","title","url"]
+      "rollUp": [
+        "code",
+        "title",
+        "url"
+      ]
     },
     "fromOpenCall": {
       "type": "string",
-      "enum": ["Yes","No"],
+      "enum": [
+        "Yes",
+        "No"
+      ],
       "description": "Was this grant made as the result of an open call for applications? Values should be 'Yes' or 'No'",
       "weight": 12,
       "title": "From an open call?"
@@ -594,17 +1261,17 @@
       "weight": 5.02
     },
     "disbursementTransaction": {
-         "items": {
-           "$ref": "#/definitions/Transaction"
-         },
-         "type": "array",
-         "description": "-",
-         "weight": 5
-       },
+      "items": {
+        "$ref": "#/definitions/Transaction"
+      },
+      "type": "array",
+      "description": "-",
+      "weight": 5
+    },
     "relatedActivity": {
       "type": "array",
       "items": {
-        "type":"string"
+        "type": "string"
       },
       "description": "The identifiers of any related activities (e.g. other grants given as part of a multi-grant project)",
       "weight": 15,
@@ -619,7 +1286,10 @@
     },
     "dataSource": {
       "format": "uri",
-      "type": ["string","null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "A web link pointing to the source of this data. This may be an original 360Giving data file, a file from which the data was converted, or an organisation website.",
       "weight": 25,
       "title": "Data Source"

--- a/tools/update_currency_codes.py
+++ b/tools/update_currency_codes.py
@@ -1,0 +1,58 @@
+"""
+Updates the currency codelist from ISO4217 files.
+Adapted from https://github.com/open-contracting/standard/ \
+blob/1.1/standard/schema/utils/fetch_currency_codelist.py
+"""
+
+import json
+import re
+from collections import OrderedDict
+
+import requests
+from lxml import etree
+
+
+def get_and_parse_xml(url):
+    return etree.fromstring(requests.get(url).content)
+
+
+# "List one: Current currency & funds code list"
+# https://www.currency-iso.org/en/home/tables/table-a1.html
+current_codes = []
+tree = get_and_parse_xml('https://www.currency-iso.org/dam/downloads/lists/list_one.xml')
+for node in tree.xpath('//CcyNtry'):
+    match = node.xpath('./Ccy')
+    # Entries like Antarctica have no universal currency.
+    if match:
+        code = node.xpath('./Ccy')[0].text
+        title = node.xpath('./CcyNm')[0].text.strip()
+        if code not in current_codes:
+            current_codes.append(code)
+
+# "List three: List of codes for historic denominations of currencies & funds"
+# https://www.currency-iso.org/en/home/tables/table-a3.html
+historic_codes = {}
+tree = get_and_parse_xml('https://www.currency-iso.org/dam/downloads/lists/list_three.xml')
+for node in tree.xpath('//HstrcCcyNtry'):
+    code = node.xpath('./Ccy')[0].text
+    title = node.xpath('./CcyNm')[0].text.strip()
+    valid_until = node.xpath('./WthdrwlDt')[0].text
+    # Use ISO8601 interval notation.
+    valid_until = re.sub(r'^(\d{4})-(\d{4})$', r'\1/\2', valid_until.replace(' to ', '/'))
+    if code not in current_codes:
+        if code not in historic_codes:
+            historic_codes[code] = {'Valid Until': valid_until}
+        # If the code is historical, use the most recent
+        elif valid_until > historic_codes[code]['Valid Until']:
+            historic_codes[code] = {'Valid Until': valid_until}
+
+historic_codes = list(historic_codes.keys())
+
+with open('../schema/360-giving-schema.json') as fp:
+    schema = json.load(fp, object_pairs_hook=OrderedDict)
+
+codes = sorted(current_codes + historic_codes)
+schema['definitions']['currency']['enum'] = codes
+
+with open('../schema/360-giving-schema.json', 'w') as fp:
+    json.dump(schema, fp, indent=2)


### PR DESCRIPTION
#109 

Please note: the schema file (360-giving-schema.json) shows a big diff due to changes in indentation/layout as a result of re-producing the file with ```json.dump()```. I don't think it is possible to preserve the previous layout using the python ```json``` module alone (it could be done using the ```tokenize``` module, but that would be kind of pointless IMO) 

'Real' changes (if any) to the schema should only affect ```schema['definitions']['currency']['enum']```, but please check when reviewing as unintended changes to the schema would obviously be quite bad.
