### PR TITLE
Add uk health and social care org-id link

### DIFF
--- a/documentation/identifiers.md
+++ b/documentation/identifiers.md
@@ -146,6 +146,7 @@ The following identifier lists are often used in 360Giving publication.
 * UK Company Number - [GB-COH](http://org-id.guide/list/GB-COH)
 * Charity Numbers - [GB-CHC](http://org-id.guide/list/GB-CHC), [GB-SC](http://org-id.guide/list/GB-SC), [GB-NIC](http://org-id.guide/list/GB-NIC)
 * Education establishments - [GB-EDU](http://org-id.guide/list/GB-EDU) and [GB-UKPRN](http://org-id.guide/list/GB-UKPRN)
+* UK health and social care organisations - [GB-NHS](http://org-id.guide/list/GB-NHS)
 * Local authorities - [GB-LAE](http://org-id.guide/list/GB-LAE) (England), [GB-LAS](http://org-id.guide/list/GB-LAS) (Scotland), [GB-PLA](http://org-id.guide/list/GB-PLA) (Wales)
 * Mutual societies - [GB-MPR](http://org-id.guide/list/GB-MPR)
 * HMRC-recognised charities - [GB-REV](http://org-id.guide/list/GB-REV)


### PR DESCRIPTION
A small change to add the org-id.guide entry for UK health and social care providers to the set of suggested common-identifier lists.

You can see this on Read the Docs version here: http://standard.threesixtygiving.org/en/nhs-org-ids/identifiers/#commonly-used-identifier-lists

The original request for that list was raised by @drkane via [org-id](https://github.com/org-id/register/issues/184) - it would be useful to have this linked from 360 as there are some organisations here that will be recipients (potentially funders too) but have no company or charity registration being in the public sector.

The NHS Digital "Health and Social Care Organisation Reference Data" has itself a [standard](http://content.digital.nhs.uk/6969) supporting it so we can be confident it follows best practices for uniqueness and persistence of those identifiers.

@kduerden can let us know if she is happy to allow this to be added.