### PR TITLE
requirements: Use newer version of sphinxcontrib-opendataservices

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ sphinx-rtd-theme==0.2.4
 -e git+https://github.com/rtfd/recommonmark.git@50be4978d7d91d0b8a69643c63450c8cd92d1212#egg=recommonmark
 -e git+https://github.com/OpenDataServices/flatten-tool.git@4e4a07a771408b3c566fa65ebbbff42c9560227a#egg=flattentool
 -e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@bfbd5bdfdea11c70f91dc7a40ffbc8722408aff4#egg=sphinxcontrib_jsonschema
--e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@23ce17656feaa237584af8822bd57ac39b498f93#egg=sphinxcontrib_opendataservices
+-e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@e1f14278807341baadf213566220f77ab27ef5e0#egg=sphinxcontrib_opendataservices
 alabaster==0.7.10
 appdirs==1.4.3
 Babel==2.3.4


### PR DESCRIPTION
Update the requirements for sphinxcontrib-opendataservices so that it is
at current HEAD and includes this fix
https://github.com/OpenDataServices/sphinxcontrib-opendataservices/commit/f84eb897d1abd75f60f4dfb680130d6919982ccc

Fixes https://github.com/ThreeSixtyGiving/standard/issues/249