### PR TITLE
Make images and links https

### DIFF
--- a/documentation/_templates/footer.html
+++ b/documentation/_templates/footer.html
@@ -15,7 +15,7 @@
   <div role="contentinfo">
     <p>
 
-    © Copyright 2016-2017, 360Giving, licensed under a a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+    © Copyright 2016-2017, 360Giving, licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
 
     {% if pagename == 'index' %}
     Icons from the Noun Project: Document by Jamison Wieser and JSON File by useiconic.com.

--- a/documentation/_templates/layout.html
+++ b/documentation/_templates/layout.html
@@ -21,7 +21,7 @@
 
 <div class="sidebar-content sidebar-content--orange">
   <h3 class="sidebar-content__heading">Useful links</h3>
-  <p class="sidebar-content__text"><a class="" href="http://www.threesixtygiving.org/">360Giving main website</a></p>
+  <p class="sidebar-content__text"><a class="" href="https://www.threesixtygiving.org/">360Giving main website</a></p>
   <p class="sidebar-content__text"><a class="" href="https://dataquality.threesixtygiving.org/">Data Quality Tool</a></p>
 </div>
 {% endblock %}

--- a/documentation/data-protection.md
+++ b/documentation/data-protection.md
@@ -31,5 +31,5 @@ Organisations:
 
 Resources:
 * [Guide to data protection: Anonymisation](https://ico.org.uk/for-organisations/guide-to-data-protection/anonymisation/)
-* [UKAN workshops](http://ukanon.net/services-for-members/advisory-service/)
+* [UKAN workshops](https://ukanon.net/services-for-members/advisory-service/)
 * [The Anonymisation Decision-Making Framework Course](https://theodi.github.io/ukan-course/#0.1)

--- a/documentation/data-protection.md
+++ b/documentation/data-protection.md
@@ -6,19 +6,19 @@ The [Data Protection Act](https://www.gov.uk/data-protection/the-data-protection
 
 ## What does data protection have to do with open data?
 
-In general, [open data](https://theodi.org/what-is-open-data) should not contain personal or sensitive personal data that could allow a living person to be identified. Data published to the [360Giving standard](http://www.threesixtygiving.org/standard/) should be anonymised to protect privacy as outlined in the ICO's [anonymisation code of practice](https://ico.org.uk/for-organisations/guide-to-data-protection/anonymisation/). There are cases where publishing personal data is in the public interest or where data can be published with the consent of the individual. We explore those cases below.
+In general, [open data](https://theodi.org/what-is-open-data) should not contain personal or sensitive personal data that could allow a living person to be identified. Data published to the [360Giving standard](https://www.threesixtygiving.org/standard/) should be anonymised to protect privacy as outlined in the ICO's [anonymisation code of practice](https://ico.org.uk/for-organisations/guide-to-data-protection/anonymisation/). There are cases where publishing personal data is in the public interest or where data can be published with the consent of the individual. We explore those cases below.
 
 ## Publishing personal data with 360Giving
-We encourage publishers to carefully consider the value of sharing any personal data as part of their 360Giving publication and discourage sharing of [sensitive personal data](http://www.legislation.gov.uk/ukpga/1998/29/section/2) (including racial or ethnic origin, medical information). 
+We encourage publishers to carefully consider the value of sharing any personal data as part of their 360Giving publication and discourage sharing of [sensitive personal data](https://www.legislation.gov.uk/ukpga/1998/29/section/2) (including racial or ethnic origin, medical information).
 
 Before making a decision on including personal data:
 
  1. Review the ICO's [Key definitions of the data protection act](https://ico.org.uk/for-organisations/guide-to-data-protection/key-definitions/) to understand the difference between non-personal data, personal data and sensitive personal data;
  2. Review the ICO's [Guide to data protection](https://ico.org.uk/for-organisations/guide-to-data-protection/) to understand your organisation's obligations;
- 3. Ensure your organisation has the [power to share the data](https://ico.org.uk/for-organisations/guide-to-data-protection/data-sharing/); 
- 
+ 3. Ensure your organisation has the [power to share the data](https://ico.org.uk/for-organisations/guide-to-data-protection/data-sharing/);
+
  Once you've decided to include personal data in your publication:
- 
+
  1. Restrict personal data to names used in official capacity, for example the contact names at the funding and recipient organisations, names of recipients of funds e.g. scholarships and identifiers that are open or in the public domain, for example [orcid](https://orcid.org/);
  2. Ensure individuals formally consent to share their data, for example as part of grant, sponsorship or employee contracts. Be aware that consent can be withdrawn at any time;
  3. Ensure individuals are informed of the scope of personal data to be shared as open data.
@@ -26,11 +26,10 @@ Before making a decision on including personal data:
 ## Where can I go for help with data protection?
 
 Organisations:
-* [The UK Anonymisation Network (UKAN)](http://ukanon.net/)
+* [The UK Anonymisation Network (UKAN)](https://ukanon.net/)
 * [ICO](https://ico.org.uk/)
 
 Resources:
 * [Guide to data protection: Anonymisation](https://ico.org.uk/for-organisations/guide-to-data-protection/anonymisation/)
 * [UKAN workshops](http://ukanon.net/services-for-members/advisory-service/)
-* [The Anonymisation Decision-Making Framework Course](http://theodi.github.io/ukan-course/#0.1)
-
+* [The Anonymisation Decision-Making Framework Course](https://theodi.github.io/ukan-course/#0.1)

--- a/documentation/footer.json
+++ b/documentation/footer.json
@@ -34,7 +34,7 @@
           "description": ""
         },
         {
-          "url": "http://data.threesixtygiving.org/",
+          "url": "https://data.threesixtygiving.org/",
           "title": "Data Registry",
           "description": ""
         },

--- a/documentation/getdata.md
+++ b/documentation/getdata.md
@@ -1,13 +1,13 @@
 # Get Data
 
-In order to help grantmakers, developers and analysts discover data that uses the 360Giving Standard, 360Giving maintains a register of data at [http://data.threesixtygiving.org/](http://data.threesixtygiving.org/)
+In order to help grantmakers, developers and analysts discover data that uses the 360Giving Standard, 360Giving maintains a register of data at [https://data.threesixtygiving.org/](https://data.threesixtygiving.org/)
 
 ## JSON Feeds
 
 ### Registry
 
 A JSON feed is available at
-[http://data.threesixtygiving.org/data.json](http://data.threesixtygiving.org/data.json). The JSON is an array of objects in the following format:
+[https://data.threesixtygiving.org/data.json](https://data.threesixtygiving.org/data.json). The JSON is an array of objects in the following format:
 
 ~~~json
 
@@ -74,5 +74,4 @@ We welcome all feedback! Please open an issue at [https://github.com/ThreeSixtyG
 
 ## License
 
-<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />All JSON feeds linked from this page are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
-
+<a rel="license" href="https://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />All JSON feeds linked from this page are licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/documentation/governance.md
+++ b/documentation/governance.md
@@ -140,9 +140,9 @@ Anyone who is a current or potential publisher or user of the 360Giving Standard
 ```eval_rst
 **Footnotes**
 
-.. [1]  For a list of current Stewardship Committee members and their Terms of Reference, visit: http://www.threesixtygiving.org/governance-of-the-360giving-standard/.
+.. [1]  For a list of current Stewardship Committee members and their Terms of Reference, visit: https://www.threesixtygiving.org/governance-of-the-360giving-standard/.
 .. [2] See https://open-stand.org/about-us/principles/.
 .. [3] See https://en.wikipedia.org/wiki/Deprecation
-.. [4] See http://cove.opendataservices.coop/360/.
+.. [4] See https://cove.opendataservices.coop/360/.
 .. [5] See Pocket Guide to Standards Development, the British Standards Institution, 2012, p.9: https://www.bsigroup.com/Documents/about-bsi/NSB/BSI-pocket-guide-to-standards-development-UK-EN.pdf.
 ```

--- a/documentation/governance.md
+++ b/documentation/governance.md
@@ -143,6 +143,6 @@ Anyone who is a current or potential publisher or user of the 360Giving Standard
 .. [1]  For a list of current Stewardship Committee members and their Terms of Reference, visit: https://www.threesixtygiving.org/governance-of-the-360giving-standard/.
 .. [2] See https://open-stand.org/about-us/principles/.
 .. [3] See https://en.wikipedia.org/wiki/Deprecation
-.. [4] See https://cove.opendataservices.coop/360/.
+.. [4] See https://dataquality.threesixtygiving.org/.
 .. [5] See Pocket Guide to Standards Development, the British Standards Institution, 2012, p.9: https://www.bsigroup.com/Documents/about-bsi/NSB/BSI-pocket-guide-to-standards-development-UK-EN.pdf.
 ```

--- a/documentation/identifiers.md
+++ b/documentation/identifiers.md
@@ -48,7 +48,7 @@ For organisation identifiers, we strongly encourage you to use an officially rec
 
 ## Get your prefix
 
-To register a prefix for your organisation see the [publisher guidance](http://www.threesixtygiving.org/support/publish-data).
+To register a prefix for your organisation see the [publisher guidance](https://www.threesixtygiving.org/support/publish-data).
 
 All registered prefixes should start with 360G unless you have been advised otherwise by the support team.
 
@@ -150,9 +150,9 @@ The following identifier lists are often used in 360Giving publication.
 * Mutual societies - [GB-MPR](http://org-id.guide/list/GB-MPR)
 * HMRC-recognised charities - [GB-REV](http://org-id.guide/list/GB-REV)
 
-If you have a registered number from some other scheme, including overseas registrars, check the [org-id List Locator](http://org-id.guide/) for a list code prefix to use. If the list code prefix you need is not listed, [contact the support team](http://www.threesixtygiving.org/contact/).
+If you have a registered number from some other scheme, including overseas registrars, check the [org-id List Locator](http://org-id.guide/) for a list code prefix to use. If the list code prefix you need is not listed, [contact the support team](https://www.threesixtygiving.org/contact/).
 
-If you do not have any external registration numbers for the organisation, use your 360Giving prefix and any internal identifier you have for this organisation. For guidance about how to create unique internal identifiers, [contact the support team](http://www.threesixtygiving.org/contact/).
+If you do not have any external registration numbers for the organisation, use your 360Giving prefix and any internal identifier you have for this organisation. For guidance about how to create unique internal identifiers, [contact the support team](https://www.threesixtygiving.org/contact/).
 
 
 ```eval_rst

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -9,7 +9,7 @@ The 360Giving data standard is:
 * **Open data driven:** providing a common way to share transparent and interoperable information on grant-making.
 * **Easy to use:** offering a simple spreadsheet format for publishing and consuming data, backed up by a structured data model, developer-friendly JSON serialisation, and conversion tools.
 * **Comprehensive:** providing a 360 degree view of grantmaking. Describing the whole grantmaking process and supporting in-depth analysis of grants, grantees and beneficiaries.
- 
+
 
 ## Templates
 
@@ -45,7 +45,7 @@ Two standard templates are available.
     </section>
 </div>
 
-Free support, helping you to publish and use 360Giving data is [available from our data support team](http://www.threesixtygiving.org/contact/).
+Free support, helping you to publish and use 360Giving data is [available from our data support team](https://www.threesixtygiving.org/contact/).
 
 Full schema documentation is [available on the reference page](reference).
 
@@ -53,7 +53,7 @@ Full schema documentation is [available on the reference page](reference).
 
 The 360Giving data standard is an open standard. You can get involved in shaping the development of the standard through:
 * [The 360 Discourse forum](https://forum.threesixtygiving.org): open for general discussions of the standard and proposed updates to the standard..
-* [The issue tracker for the standard](https://github.com/ThreeSixtyGiving/standard/issues): for bug reports.  
+* [The issue tracker for the standard](https://github.com/ThreeSixtyGiving/standard/issues): for bug reports.
 You can also contact the 360Giving data support team with your questions and suggestions.
 
 ## Contents
@@ -70,4 +70,3 @@ You can also contact the 360Giving data support team with your questions and sug
    getdata
    sc-tor
 ```
- 

--- a/documentation/licensing.md
+++ b/documentation/licensing.md
@@ -10,7 +10,7 @@ This guide is for organisations publishing grantmaking information to the 360Giv
 
 Open data is data available to everyone to use and share without restrictions. Open data is non-personal data released by people, organisations and governments.
 
-You are probably using open data without realising it. An example could be getting around London with real-time travel updates thanks to [CityMapper](https://citymapper.com "Citymapper - The Ultimate Transport App"), which uses open data from Transport for London and OpenStreetMaps amongst others. Or it could be getting up-to-date with the state of the voluntary sector with the [NCVO Almanac](https://data.ncvo.org.uk/ "NCVO UK Civil Society Almanac") which uses open data from the Charity Commission and Companies House. 
+You are probably using open data without realising it. An example could be getting around London with real-time travel updates thanks to [CityMapper](https://citymapper.com "Citymapper - The Ultimate Transport App"), which uses open data from Transport for London and OpenStreetMaps amongst others. Or it could be getting up-to-date with the state of the voluntary sector with the [NCVO Almanac](https://data.ncvo.org.uk/ "NCVO UK Civil Society Almanac") which uses open data from the Charity Commission and Companies House.
 
 ### Why license 360Giving data?
 
@@ -18,11 +18,11 @@ Without a license, data isn't open data and potential users wouldn't know what t
 
 ### Which license should you choose?
 
-While there are several choices for open data licenses, we recommend a license that doesn't restrict use but does acknowledge you, the publisher. To this end, our default recommendation is the Creative Commons Attribution 4.0 International (CC BY 4.0). 
+While there are several choices for open data licenses, we recommend a license that doesn't restrict use but does acknowledge you, the publisher. To this end, our default recommendation is the Creative Commons Attribution 4.0 International (CC BY 4.0).
 
 With this license, anyone can share or adapt your data for any purpose, even commercially. The only restrictions are they must give appropriate credit, provide a link to the license, and note any changes made. [Find out more about CC BY 4.0](https://creativecommons.org/licenses/by/4.0/ "Creative Commons Attribution 4.0 International").
 
-If you are a UK public sector organisation, we encourage you to use the [Open Government License](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ "Open Government License for public sector information"). This is the UK government's open data license which public sector bodies are encouraged to use by the [Re-use of Public Sector Information Regulations 2015 (RPSI)](https://ico.org.uk/for-organisations/guide-to-rpsi/ "Guide to RPSI").
+If you are a UK public sector organisation, we encourage you to use the [Open Government License](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ "Open Government License for public sector information"). This is the UK government's open data license which public sector bodies are encouraged to use by the [Re-use of Public Sector Information Regulations 2015 (RPSI)](https://ico.org.uk/for-organisations/guide-to-rpsi/ "Guide to RPSI").
 
 ### Where to display the license?
 
@@ -36,9 +36,9 @@ Here's an example of a license statement based on our recommended CC BY 4.0 lice
 >
 > Using the 360Giving data standard, our awarded grants since [Year] are available as [File Type] here.
 >
-> This work is licensed under the Creative Commons Attribution 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by/4.0/. This means the data is freely accessible to anyone to be used and shared as they wish. The data must be attributed to [Organisation].
+> This work is licensed under the Creative Commons Attribution 4.0 International License. To view a copy of this license, visit https://creativecommons.org/licenses/by/4.0/. This means the data is freely accessible to anyone to be used and shared as they wish. The data must be attributed to [Organisation].
 >
-> We believe that with better information, grantmakers can be more effective and strategic decision makers. 360Giving provides support for grantmakers to publish their grants data openly, to understand their data, and to use the data to create online tools that make grant making more effective. For more information, visit http://www.threesixtygiving.org/
+> We believe that with better information, grantmakers can be more effective and strategic decision makers. 360Giving provides support for grantmakers to publish their grants data openly, to understand their data, and to use the data to create online tools that make grant making more effective. For more information, visit https://www.threesixtygiving.org/
 
 ### Where can I find more information?
 

--- a/documentation/licensing.md
+++ b/documentation/licensing.md
@@ -46,7 +46,7 @@ There are several guides available on licensing open data. A good place to start
 
 If you need more in-depth guides that cover a wide variety of legal and technical considerations, we recommend:
 * [Licensing Open Data: A Practical Guide](http://discovery.ac.uk/files/pdf/Licensing_Open_Data_A_Practical_Guide.pdf "Licensing Open Data: A Practical Guide") from Higher Education Funding Council for England (HEFCE) on behalf of JISC
-* [Guide to Open Data Licensing](http://opendefinition.org/guide/data/ "Guide to Open Data Licensing") from Open Knowledge
+* [Guide to Open Data Licensing](https://opendefinition.org/guide/data/ "Guide to Open Data Licensing") from Open Knowledge
 
 ### What if I need more help?
 

--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -196,7 +196,7 @@ You can describe multiple occurrences within the Grants sheet by having multiple
 e.g. to have two related documents with their own title and web address:
 
 ```eval_rst
-+------------------------+------------------------------+------------------------+----------------------------------+
++------------------------+-------------------------------+------------------------+-----------------------------------+
 |Related Document:0:Title|Related Document:0:Web Address|Related Document:1:Title|Related Document:1:Web Address    |
 +------------------------+------------------------------+------------------------+----------------------------------+
 |A Document              |https://example.com/adocument  |Another Document        |https://example.com/anotherdocument|

--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -200,7 +200,7 @@ e.g. to have two related documents with their own title and web address:
 |Related Document:0:Title|Related Document:0:Web Address|Related Document:1:Title|Related Document:1:Web Address    |
 +------------------------+------------------------------+------------------------+----------------------------------+
 |A Document              |https://example.com/adocument  |Another Document        |https://example.com/anotherdocument|
-+------------------------+------------------------------+------------------------+----------------------------------+
++------------------------+-------------------------------+------------------------+-----------------------------------+
 ```
 
 ##### Multiple Rows

--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -4,7 +4,7 @@ This page provides reference information on publishing to the 360Giving Data Sta
 
 It assumes some technical knowledge.
 
-If you are just getting started with the 360Giving data standard, consult the [Publish Your Data](http://www.threesixtygiving.org/data/publish-data/) pages.
+If you are just getting started with the 360Giving data standard, consult the [Publish Your Data](https://www.threesixtygiving.org/data/publish-data/) pages.
 
 ## Data formats
 
@@ -70,7 +70,7 @@ The other sheets in the <a href="../_static/summary-table/360-giving-schema-titl
 
    The column titles in the extra sheets provide a handy mapping from the JSON Schema to a more human readable form, showing us all of the possible fields available in the 360Giving Data Standard.
 
-   You can use any of these column titles on your main 'grants' sheet if you wish.  
+   You can use any of these column titles on your main 'grants' sheet if you wish.
 
 2. As a way of providing information about [One to many relationships](one-to-many-relationships)
 
@@ -199,7 +199,7 @@ e.g. to have two related documents with their own title and web address:
 +------------------------+------------------------------+------------------------+----------------------------------+
 |Related Document:0:Title|Related Document:0:Web Address|Related Document:1:Title|Related Document:1:Web Address    |
 +------------------------+------------------------------+------------------------+----------------------------------+
-|A Document              |http://example.com/adocument  |Another Document        |http://example.com/anotherdocument|
+|A Document              |https://example.com/adocument  |Another Document        |https://example.com/anotherdocument|
 +------------------------+------------------------------+------------------------+----------------------------------+
 ```
 
@@ -222,7 +222,7 @@ The ```Award Date``` **must** provide a full date, including year, month and day
 In some cases, award date data exported from grant systems includes the time of the grant, using a date-time format (e.g. 2017-04-02T16:45:00Z - a grant made at 4.45pm).
 
 
-**Note** - The time component is never significant in Award Dates or Transaction Dates. Applications should ignore the time component when processing grants data. 
+**Note** - The time component is never significant in Award Dates or Transaction Dates. Applications should ignore the time component when processing grants data.
 
 
 ```eval_rst
@@ -230,7 +230,7 @@ In some cases, award date data exported from grant systems includes the time of 
 .. hint::
   You can set Excel to present a date column in YYYY-MM-DD format using a custom format `as described here`_.
 
-.. _as described here: http://superuser.com/questions/409896/how-do-i-enter-dates-in-iso-8601-date-format-yyyy-mm-dd-in-excel-and-have-exc/409899#409899
+.. _as described here: https://superuser.com/questions/409896/how-do-i-enter-dates-in-iso-8601-date-format-yyyy-mm-dd-in-excel-and-have-exc/409899#409899
 
 ```
 
@@ -278,7 +278,7 @@ You must not:
 
 ## JSON format
 
-The 360Giving standard is defined by a [JSON Schema](http://json-schema.org/), which details the entities that can be described using the standard, and the properties it recognises.
+The 360Giving standard is defined by a [JSON Schema](https://json-schema.org/), which details the entities that can be described using the standard, and the properties it recognises.
 
 At the root of the data model is a 'grant'. Grants have a number of direct properties (e.g. Title, Description, Currency, Amount Awarded etc.) and then a number of related entities, including Organisations (Funder and Recipient), Locations (Recipient, Beneficiary), Classifications, Grant Programmes, and Transactions.
 
@@ -297,7 +297,7 @@ In general, most publishers will initially only use a sub-set of the possible fe
 
 <div style="height:400px; overflow:auto; border:1px solid grey;">
 <script src="../_static/docson/widget.js"
-        data-schema="../360-giving-schema.json">      
+        data-schema="../360-giving-schema.json">
 </script>
 </div>
 


### PR DESCRIPTION
Re-do of #267 as per discussion

Most links have been updated to https. Those that haven't have pages / documents that cause browser security warnings or are unreachable when switched to https including:

* http://org-id.guide links in `identifiers.md`
* [Licensing Open Data: A Practical Guide](http://discovery.ac.uk/files/pdf/Licensing_Open_Data_A_Practical_Guide.pdf "Licensing Open Data: A Practical Guide") in `licensing.md`
* http://sphinx-doc.org/ in `_templates/footer.html`