### PR TITLE
requirements: Update MarkupSafe so it installs on Read the Docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ docutils==0.13.1
 imagesize==0.7.1
 Jinja2==2.10.3
 jsonpointer==2.0
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 packaging==16.8
 Pygments==2.2.0
 pyparsing==2.2.0


### PR DESCRIPTION
Read the Docs pulls in the latest version of setuptools, which the previous version of MarkupSafe was incompatible with.