### PR TITLE
Removing link to feedback form

### DIFF
--- a/documentation/_templates/_parts/feedback.html
+++ b/documentation/_templates/_parts/feedback.html
@@ -1,4 +1,4 @@
 <div class="box">
     <h2 class="box__heading">Getting further help</h2>
-    <p>This guidance aims to support funders through the 360Giving publishing process. If you can't find the information you need or you have further questions email <a href="mailto:support@threesixtygiving.org">360Giving Helpdesk.</a> You can help us improve this guidance by filling out our <a href="https://docs.google.com/document/d/1LitLsFnMRXRZKXeEZqw8Dw1tbR9AMDpHj0446y8l6WY/edit?usp=sharing" target="_blank">feedback form.</a></p>
+    <p>This guidance aims to support funders through the 360Giving publishing process. If you can't find the information you need or you have further questions email <a href="mailto:support@threesixtygiving.org">360Giving Helpdesk.</a></p>
 </div>


### PR DESCRIPTION
The link to feedback form is not ready yet so removing now and we can reinstate once it is ready.