### PR TITLE
Update url to grant identifier guidance

### DIFF
--- a/schema/360-giving-package-schema.json
+++ b/schema/360-giving-package-schema.json
@@ -60,7 +60,7 @@
           "properties": {
             "identifier": {
               "title": "Identifier",
-              "description": "The organisation identifier as described by [Organisation Identifier Standard](https://standard.threesixtygiving.org/en/latest/identifiers/#organisation-identifier)",
+              "description": "The organisation identifier as described by [Organisation Identifier Standard](https://standard.threesixtygiving.org/en/latest/technical/identifiers/#organisation-identifier)",
               "type": "string"
             },
             "name": {


### PR DESCRIPTION
A redirect has been put in place but because the link opens directly it causes the page to open in the schema window so better to update the url.

This is a non-normative change to a normative part of the standard. As such I believe this can be approved by ODS team, once checked, without need for a patch.

As per [this policy](https://www.threesixtygiving.org/wp-content/uploads/360Giving-Standard-Policy-Normative-and-non-normative-content_final_2020-02-28.pdf)

Non-normative change within normative content
Approval of content: 360Giving
Update actioned by: 360Giving/ODSC 
Update process: Pull requests approved by a person other than the author.

