### PR TITLE
Update to grant and org ID guidance urls

### DIFF
--- a/schema/360-giving-schema.json
+++ b/schema/360-giving-schema.json
@@ -891,7 +891,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "A globally unique identifier for this organisation. This is important to enable data on funders and recipients to be linked up across different grant-makers. The [Organisation Identifier Standard](https://standard.threesixtygiving.org/en/latest/identifiers/#organisation-identifier) guidance explains how to create this ID, based either on the known company or charity number, or upon identifiers held in the grantmaker's internal systems.",
+          "description": "A globally unique identifier for this organisation. This is important to enable data on funders and recipients to be linked up across different grant-makers. The [Organisation Identifier Standard](https://standard.threesixtygiving.org/en/latest/technical/identifiers/#organisation-identifier) guidance explains how to create this ID, based either on the known company or charity number, or upon identifiers held in the grantmaker's internal systems.",
           "weight": 0.001,
           "title": "Identifier"
         },
@@ -1094,7 +1094,7 @@
   "properties": {
     "id": {
       "type": "string",
-      "description": "The unique identifier for this grant. Made up of your 360Giving prefix, and an identifier from your records. See the [360Giving Grant identifier guidance](https://standard.threesixtygiving.org/en/latest/identifiers/#grant-identifier) for details.",
+      "description": "The unique identifier for this grant. Made up of your 360Giving prefix, and an identifier from your records. See the [360Giving Grant identifier guidance](https://standard.threesixtygiving.org/en/latest/technical/identifiers/#grant-identifier) for details.",
       "weight": 0.001,
       "title": "Identifier"
     },


### PR DESCRIPTION
A redirect has been put in place but because the link opens directly it causes the page to open in the schema window so better to update the urls - to grant and org ID guidance.

This is a non-normative change to a normative part of the standard. As such I believe this can be approved by ODS team, once checked, without need for a patch.

As per [this policy](https://www.threesixtygiving.org/wp-content/uploads/360Giving-Standard-Policy-Normative-and-non-normative-content_final_2020-02-28.pdf)

Non-normative change within normative content
Approval of content: 360Giving
Update actioned by: 360Giving/ODSC
Update process: Pull requests approved by a person other than the author.