### PR TITLE
[DO NOT MERGE] templates: update analytics URL

### DIFF
--- a/documentation/_templates/layout.html
+++ b/documentation/_templates/layout.html
@@ -27,11 +27,11 @@
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
-    var u="//matomo.opendataservices.coop/threesixtygiving/";
-    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    var u="//analytics.threesixtygiving.org/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '13']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
 <!-- End Piwik Code -->

--- a/documentation/privacy-notice.md
+++ b/documentation/privacy-notice.md
@@ -40,7 +40,7 @@ You can opt out of this processing: If you have set your web browser to "I do no
 
 Matomo also it’s own opt out mechanism:
 <!-- opt out iframe - clicking this will mean people can opt out of tracking -->
-<iframe style="border: 1; height: 150px; width: 600px;" src="https://matomo.opendataservices.coop/threesixtygiving/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=en"></iframe>
+<iframe style="border: 1; height: 150px; width: 600px;" src="https://analytics.threesixtygiving.org/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=en"></iframe>
 
 Data processors: Open Data Services Co-operative Limited, Bytemark.
 


### PR DESCRIPTION
@KDuerden this is an update that will mean that the standard will use the new analytics server when we carry out the migration. As I understand the non-normative content policy, this requires a check by 360Giving to confirm that the change is, in fact, non-normative. 

Please can you check this and confirm? 

(for the avoidance of doubt, this change has no visible effect for users!) 