### PR TITLE
Typo in Example meta sheet table

### DIFF
--- a/documentation/technical/metadata.md
+++ b/documentation/technical/metadata.md
@@ -148,7 +148,7 @@ This table provides example values for each field in the Meta sheet to demonstra
                 </td>
             </tr>
             <tr>
-                <td class="table__lead-cell" data-header="Field name">Modifield</td>
+                <td class="table__lead-cell" data-header="Field name">Modified</td>
                 <td data-header="Example value">2021-04-30T00:00:00Z</td>
                 </td>
             </tr>


### PR DESCRIPTION
Update to correct field title from Modifield to Modified

This small update to correct a typo should be classed as a non-normative change to a normative part of the Standard - [as per the policy](https://www.threesixtygiving.org/wp-content/uploads/360Giving-Standard-Policy-Normative-and-non-normative-content_final_2020-02-28.pdf). Therefore it only needs to be approved by someone other than me. 

Matt can do you do the honours? 