### PR TITLE
requirements: Upgrade flatten-tool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Sphinx==1.5.3
 sphinx-intl==0.9.9
 transifex-client==0.12.4
 sphinx-rtd-theme==0.2.4
--e git+https://github.com/OpenDataServices/flatten-tool.git@4e4a07a771408b3c566fa65ebbbff42c9560227a#egg=flattentool
+flattentool==0.20.0
 sphinxcontrib-opendataservices-jsonschema==0.1.0
 -e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@e1f14278807341baadf213566220f77ab27ef5e0#egg=sphinxcontrib_opendataservices
 alabaster==0.7.10
@@ -27,5 +27,5 @@ urllib3==1.26.5
 jdcal==1.2
 jsonref==0.1
 lxml==4.9.1
-openpyxl==2.3.2
+openpyxl==3.0.10
 schema==0.4.0


### PR DESCRIPTION
Fixes display of Recipient Ind.

Changes sheet names to be based on titles. e.g. "Actual Dates" instead of "actualDates".

See the generated spreadsheet https://standard.threesixtygiving.org/en/upgrade-flattentool/_static/summary-table/360-giving-schema-titles.xlsx

Reference page should look the same https://standard.threesixtygiving.org/en/upgrade-flattentool/technical/reference/