### PR TITLE
Non normative regranting 2023 01

### DIFF
--- a/documentation/guidance/cf-guidance.md
+++ b/documentation/guidance/cf-guidance.md
@@ -2,7 +2,7 @@
 
 <div class="box box--teal">
     <h2 class="box__heading">Not using the Digits2 grants management system?</h2>
-    <p>This guidance is for community foundations using the Digits2 grants management system on Salesforce only. If you do not use Digits2 use the buttons below to return to the guidance on preparing your data or continue to guidance about testing your data quality.</p></div>
+    <p>This guidance is for community foundations using the Digits2 grants management system on Salesforce only. If you do not use Digits2 use the side menu to go to guidance on preparing your data.</p></div>
 
 ## Overview
 In collaboration with UKCF, 360Giving has supported the development of a tool for the Digits2 (D2) system which means that grant information can be extracted from your system ready-formatted to the 360Giving Data Standard.

--- a/documentation/guidance/cf-guidance.md
+++ b/documentation/guidance/cf-guidance.md
@@ -1,12 +1,8 @@
-# Data preparation guide for community foundations
+# Guide for Community Foundations
 
 <div class="box box--teal">
     <h2 class="box__heading">Not using the Digits2 grants management system?</h2>
     <p>This guidance is for community foundations using the Digits2 grants management system on Salesforce only. If you do not use Digits2 use the buttons below to return to the guidance on preparing your data or continue to guidance about testing your data quality.</p></div>
-
-<p>
-    <a href="../../guidance/prepare-data" class="button button--teal">Previous</a> <a href="../../guidance/data-quality/" class="button button--teal">Next</a>
-</p>
 
 ## Overview
 In collaboration with UKCF, 360Giving has supported the development of a tool for the Digits2 (D2) system which means that grant information can be extracted from your system ready-formatted to the 360Giving Data Standard.
@@ -208,7 +204,7 @@ Once you have exported a file of your data using the 360Giving extract, the next
 
 Each Community Foundation is responsible for the data it publishes.  You can check that your data is valid using this Data Quality Tool developed, which will tell you if there are any issues with your dataset.
 
-Click **Next** below to read our guidance on checking data quality before publishing your data.
+See the guidance on [checking data quality](../../guidance/data-quality/) before publishing your data.
 
 ## Publishing your 360Giving data
 Once you are happy with your data file and the Data Quality tool shows that the data is valid, the next step is to find a place on your website for hosting the file and outlining the open license you are releasing it under.

--- a/documentation/guidance/cf-guidance.md
+++ b/documentation/guidance/cf-guidance.md
@@ -148,7 +148,7 @@ The following system-generated fixed or calculated values will not appear in the
             <tr>
                 <td class="table__lead-cell" data-header="360Giving field">Currency</td>
                 <td data-header="Salesforce source">Default Value</td>
-                <td data-header="Notes">The grant identifier will be the Grant Application unique Grant Application reference number prefixed with each Community Foundation’s unique organization identifier e.g. 360G-CF-XXXXXXX</td>
+                <td data-header="Notes">Default to GBP</td>
                 </td>
             </tr>
             <tr>

--- a/documentation/guidance/index.md
+++ b/documentation/guidance/index.md
@@ -15,11 +15,12 @@ This isn’t a reporting process, it’s an opportunity to let people know about
    plan-the-process
    data-protection
    prepare-data
-   location-guide
-   cf-guidance
    data-quality
    publish-data-openly
    making-updates
    using-data
+   cf-guidance
+   location-guide
+   regranting
 
 ```

--- a/documentation/guidance/location-guide.md
+++ b/documentation/guidance/location-guide.md
@@ -1,4 +1,4 @@
-# 360Giving guide to location data
+# Guide to location data
 
 ## Why is location data important?
 Location data helps users to understand where organisations are based or activities are happening, which helps to build a more complete picture of where funding is going geographically.
@@ -60,7 +60,7 @@ See our guidance on [converting postcodes into geocodes](converting-postcodes-in
 ### Recipient location codes
 In cases when it isn’t possible or appropriate to publish postal codes, it is possible to publish recipient location in the form of Office for National Statistics (ONS) geocodes.
 
-When 360Giving data includes recipient location codes at **Local Authority** or **Ward** level, these will work with the <a href="https://help.grantnav.threesixtygiving.org/en/latest/locations.html" target="_blank">location filtering functions</a> of GrantNav, 360Giving’s search engine for grants data.
+When 360Giving data includes recipient location codes at UK **Country**, **English Region**, **Local Authority**, **Ward** or **LSOA** level, these will work with the <a href="https://help.grantnav.threesixtygiving.org/en/latest/locations.html" target="_blank">location filtering functions</a> of GrantNav, 360Giving’s search engine for grants data.
 
 The fields used to share recipient location geocodes should be accompanied by fields for the location name and geocode type whenever possible.
 
@@ -124,7 +124,7 @@ Also avoid using ambiguous terms such as ‘National’ which in a UK context co
 
 Including geocodes that correspond with the beneficiary location names increases the usability of the data by providing a consistent way to identify these places, which make the data comparable across different funders. 
 
-Data with geocodes can be used to produce maps showing the geographic distribution of funding and allow grants data to be linked with other data sources, such as official statistics.
+Data with geocodes can be used to produce maps showing the geographic distribution of funding and allow grants data to be linked with other data sources, such as official statistics. When 360Giving data includes beneficiary location codes at UK **Country**, **English Region**, **Local Authority**, **Ward** or **LSOA** level, these will work with the <a href="https://help.grantnav.threesixtygiving.org/en/latest/locations.html" target="_blank">location filtering functions</a> of GrantNav, 360Giving’s search engine for grants data.
 
 The fields used to share beneficiary location geocodes should be accompanied by fields for the location name and geocode type whenever possible.
 
@@ -312,5 +312,3 @@ In addition to providing location information for recipients and beneficiaries, 
 
 View the full range of available <a href="https://standard.threesixtygiving.org/en/latest/technical/reference/#funding-org" target="_blank">funding organisation address fields</a> or <a href="https://standard.threesixtygiving.org/en/latest/technical/reference/#funding-org-location" target="_blank">funding organisation location fields.</a>
 
-### What's next?
-Read our guidance to find out how to check your data using the 360Giving Data Quality Tool.

--- a/documentation/guidance/prepare-data.md
+++ b/documentation/guidance/prepare-data.md
@@ -217,7 +217,7 @@ Ward Name = Recipient Org:Location:Name
 9\. Re-save as Excel file (xlsx file format).
 
 ### What's next?
-Read our guide to preparing and publishing location data.
+Read our guidance to find out how to check your data using the 360Giving Data Quality Tool.
 
 
 

--- a/documentation/guidance/regranting.md
+++ b/documentation/guidance/regranting.md
@@ -94,4 +94,4 @@ The responsibility for using the codelist sits with the “donor funder” givin
 Funders that receive grants for onward distribution as grants are not expected to use this codelist, except in cases where they are also awarding grants that are intended for redistribution. 
 Grants awarded to recipients to fund projects and activities **must not** be categorised using this codelist: the field should be left blank or not supplied.
 ## Guidance on using the codelist
-Read our guidance about [how to use the codelists](../technical/codelists) for further information about how to add the For Regrant Type field and Regrant Type codes to 360Giving data.
+Read our guidance about [how to use the codelists](../technical/codelists) for further information about how to add the **For Regrant Type** field and **Regrant Type** codes to 360Giving data.

--- a/documentation/guidance/regranting.md
+++ b/documentation/guidance/regranting.md
@@ -63,7 +63,7 @@ Grants awarded for regranting that include the administration costs of the recip
 
 ### Still not sure which code to use?
 The code descriptions and guidance provide examples of which codes to use to categorise types of grants for regranting. If the grant you want to categorise could fit into more than one category, please label using the primary type.
-If you are still not sure which category is appropriate for your grant contact support@threesixtygiving.org for further guidance.
+If you are still not sure which category is appropriate for your grant contact <support@threesixtygiving.org> for further guidance.
 
 ## Sharing further information about your grants for redistribution
 The **Regrant Type** code list provides a consistent and comparable way to identify your grants as being intended for redistribution. 
@@ -90,8 +90,8 @@ Alongside the codes, it is recommended that you use other 360Giving Data Standar
     - **Description:** Capital funding for the installation of accessible toilets in village halls and community centres in Cambridgeshire; to be awarded by Partner Funder under the 2023 grant programme.
 
 ## Who should use the Regrant Type codelist?
-The responsibility for using the codelist sits with the “donor funder” giving the grant intended for redistribution. This means the funder that is named and identified by the 360Giving data fields Funding Org:Name and Funding Org:Identifier.
+The responsibility for using the codelist sits with the “donor funder” giving the grant intended for redistribution. This means the funder that is named and identified by the 360Giving data fields **Funding Org:Name** and **Funding Org:Identifier**.
 Funders that receive grants for onward distribution as grants are not expected to use this codelist, except in cases where they are also awarding grants that are intended for redistribution. 
-Grants awarded to recipients to fund projects and activities must not be categorised using this codelist: the field should be left blank or not supplied.
+Grants awarded to recipients to fund projects and activities **must not** be categorised using this codelist: the field should be left blank or not supplied.
 ## Guidance on using the codelist
 Read our guidance about [how to use the codelists](../technical/codelists) for further information about how to add the For Regrant Type field and Regrant Type codes to 360Giving data.

--- a/documentation/guidance/regranting.md
+++ b/documentation/guidance/regranting.md
@@ -1,0 +1,1 @@
+# Guide to regranting


### PR DESCRIPTION
This PR is to add non-normative guidance on the use of **For Regrant Type** field and **For Regrant** codelist in the standard documentation. As this sits in the 'publisher guidance' parts of the doc, this can be set up and approved without reference to the Standard governance process.

As well as adding the new guidance, we've also reordered and renamed some pages in the guidance, and I've also taken the opportunity to correct a few typos/mistakes. These changes are also non-normative sections.

@mrshll1001 can you check everything is in order - raise queries, amend if needed or merge as appropriate. As per Planio issue [37424](https://opendataservices.plan.io/issues/37424)