### PR TITLE
Add Extensions Feature

### DIFF
--- a/documentation/technical/metadata.md
+++ b/documentation/technical/metadata.md
@@ -69,7 +69,7 @@ Find the details of the current version in the <a href="https://github.com/Three
 
 **Extensions**
 
-This is a text field that can be used to declare a list of extensions used in the file. Each extension is represented by a code, and multiple extensions can be declared by separating them with a semicolon `;` character.
+This is a text field that can be used to declare a list of extensions used in the file. Each extension is represented by a short string &ndash; which is a piece of text like a code &ndash; and multiple extensions can be declared by separating them with a semicolon `;` character.
 
 **Title and Description**
 

--- a/documentation/technical/metadata.md
+++ b/documentation/technical/metadata.md
@@ -67,6 +67,10 @@ This is for the version of the 360Giving Data Standard being used, so not the ve
 
 Find the details of the current version in the <a href="https://github.com/ThreeSixtyGiving/standard/releases" target="_blank" >Releases changelog</a>. 
 
+**Extensions**
+
+This is a text field that can be used to declare a list of extensions used in the file. Each extension is represented by a code, and multiple extensions can be declared by separating them with a semicolon `;` character.
+
 **Title and Description**
 
 These are text fields that can be used to provide information about the name of the file and its contents, and provide further contextual information if appropriate.

--- a/documentation/technical/reference.md
+++ b/documentation/technical/reference.md
@@ -52,6 +52,7 @@ The [Additional fields](additional-fields) section provides details of all other
 We also provide a version of the <a href="../../_static/360-giving-schema-titles-with-meta-tab-2023.xlsx">360Giving Spreadsheet Template with the Metadata template included</a>. The 'Meta' sheet may be used to publish authoritative metadata about the publisher, the file or dataset. The term we use for this is a 'data package'. The 'Meta' sheet includes sections for:
 
 * The version of the 360Giving Schema used for the file
+* A list of 360Giving extensions used in the file
 * The title and description of the file
 * The dates when the file was first issued and last modified
 * Information about the publisher such as name, logo, website and identifier

--- a/schema/360-giving-package-schema.json
+++ b/schema/360-giving-package-schema.json
@@ -17,6 +17,15 @@
           "type": "string",
           "pattern": "^(\\d+\\.)(\\d+)$"
         },
+	"extensions": {
+	  "title": "Extensions",
+	  "description": "An array of strings which refer to Extensions in use by this 360Giving data file. Please see the Guidance for details.",
+	  "type": "array",
+	  "items": {
+	    "type": "string"
+	  },
+	  "uniqueItems": true
+	},
         "title": {
           "title": "Title",
           "description": "The title of the 360Giving data package. Should be a human readable version of information contained in the filename of the data and should be unique ",

--- a/schema/360-giving-package-schema.json
+++ b/schema/360-giving-package-schema.json
@@ -19,7 +19,7 @@
         },
 	"extensions": {
 	  "title": "Extensions",
-	  "description": "An array of strings which refer to Extensions in use by this 360Giving data file. Please see the Guidance for details.",
+	  "description": "An array of strings which refer to 360Giving Extensions in use by this data file. See the [360Giving Extensions guidance](https://standard.threesixtygiving.org/en/latest/technical/metadata/#field-guidance) for details.",
 	  "type": "array",
 	  "items": {
 	    "type": "string"


### PR DESCRIPTION
This PR responds to the latest SC approval that an `extensions` array is added to the 360Giving Package Schema (where metadata is):

| Property | Title | Description | Type |
|-------------|--------|--------------------|------|
|`extensions`|Extensions|An array of strings which refer to Extensions in use by this 360Giving data file. Please see the Guidance for details.| Array of Strings |

Each item in the array must be a string. I have also used `uniqueItems: true` to enforce that a publisher cannot accidentally input the same extension twice, this is to support tooling resolving things. If this is out of scope from the SC mandate, I am happy to remove this before merging.

I have confirmed:

* The changes are valid JSON
* The changes are valid JSON Schema (draft 04)
* The JSON schema behaves as expected
  * `extensions` is not required
  * any non-string element of the array is invalid
  * duplicate elements are invalid e.g. `["dei", "dei"]` will throw an error