### PR TITLE
Bring geoTypeCodelist column names in line with other codelists

### DIFF
--- a/codelists/geoCodeType.csv
+++ b/codelists/geoCodeType.csv
@@ -1,4 +1,4 @@
-Code,Name,Description,Documentation (URL),Values (URL)
+Code,Title,Description,Documentation (URL),Values (URL)
 OA,Output Areas,An ONS Statistical Building Block codelist,http://statistics.data.gov.uk/id/statistical-entity/E00,http://statistics.data.gov.uk/id/statistical-geography/E00000001
 LSOA,"Super Output Areas, Lower Layer",An ONS Statistical Building Block codelist,http://statistics.data.gov.uk/id/statistical-entity/E01,http://statistics.data.gov.uk/id/statistical-geography/E01000001
 MSOA,"Super Output Areas, Middle Layer",An ONS Statistical Building Block codelist,http://statistics.data.gov.uk/id/statistical-entity/E02,http://statistics.data.gov.uk/id/statistical-geography/E02000001


### PR DESCRIPTION
Fixes #348 

Changes `Name` to `Title` to bring in line with other codelists.

This doesn't introduce any new features or backwards incompatible changes to the standard.

I think this is a PATCH because it's a backwards compatible bug fix; validation should not be affected at all and tools can expect to behave properly now.

@michaelwood does this create any problems for tooling? Thinking of the fact you mentioned it in [/grantnav/#976](https://github.com/ThreeSixtyGiving/grantnav/issues/976)