### PR TITLE
Fixed description of FRG050 in regrantType.csv as per discussion

### DIFF
--- a/codelists/regrantType.csv
+++ b/codelists/regrantType.csv
@@ -3,6 +3,6 @@ FRG010,Common Regrant,"A grant awarded to a single grantmaking organisation for 
 FRG020,Transfer to intermediary,"A grant awarded to an intermediary, such as a network or federated charity, for distribution as payment to organisation(s) for redistribution as grants to end recipients."
 FRG030,Match funding,"A grant awarded to grantmaking organisations for match funding and onwards distribution as grants to end recipients."
 FRG040,Funder collaboration,"Grants awarded by multiple funders to a single grantmaking organisation to create a fund for redistribution as grants to end recipients."
-FRG050,Fiscal sponsor,"Grant awarded to an organisation acting as an agent for the funder, to make grant payment on its behalf to the defined recipient(s)."
+FRG050,Fiscal sponsor,"Grant awarded to an organisation acting as an agent for the funder, to make grant payments on its behalf to the defined recipient(s)."
 FRG060,Endowment,"A single grant awarded or transfer of capital to either establish or substantially fund a grantmaking organisation or Fund."
 FRG070,Multipurpose,"Grant to recipient for activities that include making onward grants, as well as funding other activities not related to the distribution of grants."


### PR DESCRIPTION
Fixes #338 

Description of FRG050 is changed from:

> Grant awarded to an organisation acting as an agent for the funder, to make grant payment on its behalf to the defined recipient(s).

to:

> Grant awarded to an organisation acting as an agent for the funder, to make grant payments on its behalf to the defined recipient(s).

Upon approval, this will be merged into `1.4-staging` for inclusion with 1.4