### PR TITLE
Fix errors from conf.py for Read The Docs builds

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -130,13 +130,20 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
-import os
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+
+# This started causing errors, so removing it from the conditional statement and replacing it with the above lines
+# import os
+# on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+# 
+# if not on_rtd:  # only import and set the theme if we're building docs locally
+#     import sphinx_rtd_theme
+#     html_theme = 'sphinx_rtd_theme'
+#     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # otherwise, readthedocs.org uses their theme by default, so no need to specify it
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -22,6 +22,7 @@ import os
 import json
 import sys
 import datetime
+import sphinx_rtd_theme
 sys.path.insert(0, os.path.abspath('.'))
 from recommonmark.transform import AutoStructify
 from recommonmark.parser import CommonMarkParser

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -132,6 +132,7 @@ todo_include_todos = False
 #
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
 
+# We don't do a check for RTD environment anymore since https://github.com/ThreeSixtyGiving/standard/pull/371
 
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]


### PR DESCRIPTION
Some of our recent readthedocs builds have been failing, and this became evident after changes from #370 were merged and didn't appear on the live docs site.

Error log for the build is [here](https://readthedocs.org/projects/threesixtygiving-standard/builds/21753072/).

It appears to stem from some things inside `conf.py`, where a theme variable is only set when not inside the RTD environment.

I'm not sure on the details, but glancing at the pre-existing code and [this guidance](https://docs.readthedocs.io/en/stable/faq.html#how-do-i-change-behavior-when-building-with-read-the-docs), it may be that the way to detect this may have changed?

This bugfix basically removes the conditional logic and imports the theme regardless of environment. The [docs for the branch](https://standard.threesixtygiving.org/en/bugfix-rtd-configuration/#) appear to build ok, but **I'm not sure whether this change represents good practice** for a `conf.py` file.

Please amend as needed, or merge in if this is OK.