### PR TITLE
Removed type 'null' from countryCode

### DIFF
--- a/schema/360-giving-schema.json
+++ b/schema/360-giving-schema.json
@@ -472,10 +472,7 @@
           "title": "Name"
         },	
         "countryCode": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "codelist": "countryCode.csv",
           "enum": [
             "AF",


### PR DESCRIPTION
countryCode allows for a type of either 'string' or 'null'. Unless there
is a specific reason why null is permitted as a countryCode we should
amend this.

The semantics of having a type of null in JSON Schema:

https://json-schema.org/understanding-json-schema/reference/null

I did want to flag that this is such an odd choice that it may have been deliberate i.e. if we wanted to accommodate unrecognised territories which are not yet assigned a countryCode
