### PR TITLE
documentation/conf.py: New RTD config requirements

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -27,6 +27,17 @@ sys.path.insert(0, os.path.abspath('.'))
 from recommonmark.transform import AutoStructify
 from recommonmark.parser import CommonMarkParser
 
+# -- Read the Docs --------------------------------------------------------
+
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ jsonref==0.1
 lxml==4.9.1
 openpyxl==3.0.10
 schema==0.4.0
+setuptools==65.5.0


### PR DESCRIPTION
This adds the fix to ensure that the readthedocs builds continue building. Build linked below:

* https://standard.threesixtygiving.org/en/eld_rtd_config_update/