### PR TITLE
Remove Versions from standard documentation sidebar

### DIFF
--- a/documentation/_templates/base.html
+++ b/documentation/_templates/base.html
@@ -144,7 +144,7 @@
                 {% include '_parts/sidebar-list.html' %}
                 {% endblock %}
                 {% include "searchbox.html" %}
-                {% include 'versions.html' %}
+                
               </nav>
               {% endblock %}
             </aside>


### PR DESCRIPTION
Based on discussions in the internal [Planio issue](https://opendataservices.plan.io/issues/51965), the versions section from the sidebar is removed. ![image](https://github.com/user-attachments/assets/8d4a7c20-93c5-472f-88ec-d3eb34894e3b)