### PR TITLE
ci: Replace deprecated actions/cache in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,18 +3,15 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.7
         architecture: x64
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip
+        cache: 'pip'
     - run: pip install jsonschema
     - run: wget "http://json-schema.org/draft-04/schema" -O schemaschema
     - run: python -m jsonschema -V Draft4Validator -i schema/360-giving-schema.json -i schema/360-giving-package-schema.json schemaschema


### PR DESCRIPTION
switch to using the setup-python action's built in pip cache support, and update actions versions.