### PR TITLE
Fixed broken url in package schema

### DIFF
--- a/schema/360-giving-package-schema.json
+++ b/schema/360-giving-package-schema.json
@@ -19,7 +19,7 @@
         },
 	"extensions": {
 	  "title": "Extensions",
-	  "description": "An array of strings which refer to 360Giving Extensions in use by this data file. See the [360Giving Extensions guidance](https://standard.threesixtygiving.org/en/latest/metadata/#extensions-to-360Giving-data-standard) for details.",
+	  "description": "An array of strings which refer to 360Giving Extensions in use by this data file. See the [360Giving Extensions guidance](https://standard.threesixtygiving.org/en/latest/technical/metadata/#extensions-to-360Giving-data-standard) for details.",
 	  "type": "array",
 	  "items": {
 	    "type": "string"


### PR DESCRIPTION
Fixes #401

Fixed broken URL in the the `extensions` field of the package schema to point towards the correct location in the documentation

This represents a PATCH upgrade, so once we're happy that this is correct we can do the needful re notifying the SC and community.