### PR TITLE
workflows: Add test to build docs in CI

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,17 @@
+name: Build docs
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+        architecture: x64
+        cache: 'pip'
+    - run: pip install -r requirements.txt
+    - run: cd documentation; make html
+


### PR DESCRIPTION
This ensures any changes related to the build process for building documentation will be flagged up on github if there are any issues.