### PR TITLE
github: specified version for check-jsonschema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,6 @@ jobs:
         python-version: 3.12
         architecture: x64
         cache: 'pip'
-    - run: pip install check-jsonschema
+    - run: pip install check-jsonschema==0.33.2
     - run: check-jsonschema --check-metaschema schema/360-giving-schema.json schema/360-giving-package-schema.json
 


### PR DESCRIPTION
Updated the github workflow for installing check-jsonschema via pip to specify verion 0.33.2, which is the latest version as of 2025-07-17.