### PR TITLE
schema: Update $id in schemas to match release number

### DIFF
--- a/schema/360-giving-package-schema.json
+++ b/schema/360-giving-package-schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://raw.githubusercontent.com/ThreeSixtyGiving/standard/1.4.2/schema/360-giving-package-schema.json",
+    "$id": "https://raw.githubusercontent.com/ThreeSixtyGiving/standard/1.4.3/schema/360-giving-package-schema.json",
     "$schema": "http://json-schema.org/draft/2020-12/schema",
     "title": "Schema for a 360Giving Data Grant Package",
     "type": "object",

--- a/schema/360-giving-schema.json
+++ b/schema/360-giving-schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/ThreeSixtyGiving/standard/1.4.2/schema/360-giving-schema.json",
+  "$id": "https://raw.githubusercontent.com/ThreeSixtyGiving/standard/1.4.3/schema/360-giving-schema.json",
   "$schema": "http://json-schema.org/draft/2020-12/schema",
   "title": "360Giving Data Standard Schema",
   "type": "object",


### PR DESCRIPTION
Updated the value of $id in each schema file to match the current PATCH level: 1.4.3

In the future, we should probably look to ensure this is done before issuing the release itself. I'll draft up a workflow for this.