### PR TITLE
documentation/css: hid rtd-search-form

### DIFF
--- a/documentation/_static/css/custom.css
+++ b/documentation/_static/css/custom.css
@@ -1,3 +1,6 @@
+/* Hide RTD Search Form: https://opendataservices.plan.io/issues/58218 */
+#rtd-search-form { display: none }
+
 /* boxes */
 
 .prose .admonition, .admonition, .prose details {


### PR DESCRIPTION
As part of https://opendataservices.plan.io/issues/58218, while we await fixing the sphinx search functionality we decided that it might be best to hide the search bar if possible.

This hides the search bar by including a CSS rule to make the search form not display.