### PR TITLE
docs: correct link on landing page

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -2,7 +2,7 @@
 
 Our step-by-step guidance and resources for publishers can now be accessed on 360Giving's main website.
 
-<a class="button" href="https://www.360giving.org/explore/before-you-start/">Get started here</a>
+<a class="button" href="https://www.360giving.org/publish/guidance/before-you-start/">Get started here</a>
 
 Or, jump straight into the stage you're at:
 
@@ -12,7 +12,7 @@ Or, jump straight into the stage you're at:
 4. [Post-Publishing &ndash; showcase your data and start using it](https://www.360giving.org/publish/guidance/post-publishing/)
 5. [Re-publish &ndash; go through the process again and improve your data quality](https://www.360giving.org/publish/guidance/re-publishing/)
 
-But if you're looking for technical documentation, you've come to the right place
+But if you're looking for technical documentation, you've come to the right place.
 
 # 360Giving Data Standard documentation
 


### PR DESCRIPTION
Updated the link on the landing page to the correct one, and fixed a minor typo